### PR TITLE
Move LinkPreviewDetectorType into this framework

### DIFF
--- a/ZMCLinkPreview/LinkPreviewDetector.swift
+++ b/ZMCLinkPreview/LinkPreviewDetector.swift
@@ -19,7 +19,11 @@
 
 import Foundation
 
-public final class LinkPreviewDetector : NSObject {
+@objc public protocol LinkPreviewDetectorType {
+    @objc optional func downloadLinkPreviews(inText text: String, completion: @escaping ([LinkPreview]) -> Void)
+}
+
+public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
     
     private let blacklist = PreviewBlacklist()
     private let linkDetector : NSDataDetector? = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)


### PR DESCRIPTION
LinkPreviewDetector needs to conform to this protocol to enable testing in zmessaging