### PR TITLE
Fix data task completion closure type and remove force casting to it

### DIFF
--- a/ZMCLinkPreview/URLSessionProtocols.swift
+++ b/ZMCLinkPreview/URLSessionProtocols.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 
-typealias DataTaskCompletion = (Data?, URLResponse?, NSError?) -> Void
+typealias DataTaskCompletion = (Data?, URLResponse?, Error?) -> Void
 
 protocol URLSessionType {
     func dataTask(with request: URLRequest) -> URLSessionDataTaskType
@@ -42,6 +42,6 @@ extension URLSession: URLSessionType {
     }
     
     func dataTaskWithURL(_ url: URL, completionHandler: @escaping DataTaskCompletion) -> URLSessionDataTaskType {
-        return (dataTask(with: url, completionHandler: completionHandler as! (Data?, URLResponse?, Error?) -> Void) as URLSessionDataTask) as URLSessionDataTaskType
+        return (dataTask(with: url, completionHandler: completionHandler) as URLSessionDataTask) as URLSessionDataTaskType
     }
 }


### PR DESCRIPTION
# What's in this PR?

* The migrator inserted a force cast to a closure which was not converted from `NSError` to `Error` yet which caused a crash.