### PR TITLE
Try ISO-8859-1 as well as ascii string encoding

### DIFF
--- a/WireLinkPreview/MetaStreamContainer.swift
+++ b/WireLinkPreview/MetaStreamContainer.swift
@@ -47,10 +47,16 @@ final class MetaStreamContainer {
     }
 
     private func updateReachedEndOfHead(withData data: Data) {
-        guard let string = String(data: data, encoding: String.Encoding.utf8)?.lowercased() else { return }
+        guard let string = parseString(from: data)?.lowercased() else { return }
         if string.contains(OpenGraphXMLNode.headEnd.rawValue) {
             reachedEndOfHead = true
         }
+    }
+
+    private func parseString(from data: Data) -> String? {
+        return String(data: data, encoding: .utf8)
+            ?? String(data: data, encoding: .isoLatin1)
+            ?? String(data: data, encoding: .ascii)
     }
 
 }

--- a/WireLinkPreview/MetaStreamContainer.swift
+++ b/WireLinkPreview/MetaStreamContainer.swift
@@ -47,7 +47,7 @@ final class MetaStreamContainer {
     }
 
     private func updateReachedEndOfHead(withData data: Data) {
-        guard let string = String(data: data, encoding: .utf8)?.lowercased() else { return }
+        guard let string = parseString(from: data)?.lowercased() else { return }
         if string.contains(OpenGraphXMLNode.headEnd.rawValue) {
             reachedEndOfHead = true
         }

--- a/WireLinkPreview/MetaStreamContainer.swift
+++ b/WireLinkPreview/MetaStreamContainer.swift
@@ -25,7 +25,7 @@ final class MetaStreamContainer {
     var bytes = Data()
     
     var stringContent: String? {
-        return String(data: bytes, encoding: String.Encoding.utf8)
+        return parseString(from: bytes)
     }
     
     var head: String? {
@@ -47,7 +47,7 @@ final class MetaStreamContainer {
     }
 
     private func updateReachedEndOfHead(withData data: Data) {
-        guard let string = parseString(from: data)?.lowercased() else { return }
+        guard let string = String(data: data, encoding: .utf8)?.lowercased() else { return }
         if string.contains(OpenGraphXMLNode.headEnd.rawValue) {
             reachedEndOfHead = true
         }
@@ -56,7 +56,6 @@ final class MetaStreamContainer {
     private func parseString(from data: Data) -> String? {
         return String(data: data, encoding: .utf8)
             ?? String(data: data, encoding: .isoLatin1)
-            ?? String(data: data, encoding: .ascii)
     }
 
 }

--- a/WireLinkPreview/PreviewDownloader.swift
+++ b/WireLinkPreview/PreviewDownloader.swift
@@ -70,8 +70,12 @@ final class PreviewDownloader: NSObject, URLSessionDataDelegate, PreviewDownload
     }
     
     func urlSession(_ session: URLSessionType, task: URLSessionDataTaskType, didCompleteWithError error: NSError?) {
+        guard let url = task.originalRequest?.url, let completion = completionByURL[url] else { return }
+        if let container = containerByTaskID[task.taskIdentifier], nil == container.stringContent && nil == error {
+            return completeAndCleanUp(completion, result: nil, url: url, taskIdentifier: task.taskIdentifier)
+        }
+
         guard let errorCode = error?.code , errorCode != URLError.cancelled.rawValue else { return }
-        guard let url = task.originalRequest?.url, let completion = completionByURL[url], error != nil else { return }
         completeAndCleanUp(completion, result: nil, url: url, taskIdentifier: task.taskIdentifier)
     }
     

--- a/WireLinkPreview/PreviewDownloader.swift
+++ b/WireLinkPreview/PreviewDownloader.swift
@@ -49,6 +49,7 @@ final class PreviewDownloader: NSObject, URLSessionDataDelegate, PreviewDownload
         configuration.timeoutIntervalForRequest = 10
         configuration.timeoutIntervalForResource = 20
         configuration.httpShouldSetCookies = false
+        configuration.isDiscretionary = false
         session = urlSession ?? Foundation.URLSession(configuration: configuration, delegate: self, delegateQueue: parsingQueue)
     }
     
@@ -70,7 +71,7 @@ final class PreviewDownloader: NSObject, URLSessionDataDelegate, PreviewDownload
     
     func urlSession(_ session: URLSessionType, task: URLSessionDataTaskType, didCompleteWithError error: NSError?) {
         guard let errorCode = error?.code , errorCode != URLError.cancelled.rawValue else { return }
-        guard let url = task.originalRequest?.url, let completion = completionByURL[url] , error != nil else { return }
+        guard let url = task.originalRequest?.url, let completion = completionByURL[url], error != nil else { return }
         completeAndCleanUp(completion, result: nil, url: url, taskIdentifier: task.taskIdentifier)
     }
     

--- a/WireLinkPreviewTests/ImageDownloaderTests.swift
+++ b/WireLinkPreviewTests/ImageDownloaderTests.swift
@@ -126,7 +126,7 @@ class ImageDownloaderTests: XCTestCase {
         let completionExpectation = expectation(description: "It should call the completion handler")
         let url = URL(string: "www.example.com")!
         
-        let data = "test data".utf8Data
+        let data = "test data".data(using: .utf8)!
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: headers)
         
         mockSession.dataTaskGenerator = { url, completion in

--- a/WireLinkPreviewTests/MetaStreamContainerTests.swift
+++ b/WireLinkPreviewTests/MetaStreamContainerTests.swift
@@ -41,51 +41,51 @@ class MetaStreamContainerTests: XCTestCase {
         assertThatItAppendsBytes(encoding: .ascii)
     }
 
-    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_Lowercase() {
+    func testThatItSets_reachedEndOfHead_WhenDataContainsHead_Lowercase() {
         assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</head>")
     }
     
-    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_Capitalized() {
+    func testThatItSets_reachedEndOfHead_WhenDataContainsHead_Capitalized() {
         assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</Head>")
     }
     
-    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_Uppercase() {
+    func testThatItSets_reachedEndOfHead_WhenDataContainsHead_Uppercase() {
         assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</HEAD>")
     }
     
-    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_WithSpaces() {
+    func testThatItSets_reachedEndOfHead_WhenDataContainsHead_WithSpaces() {
         assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</head >", shouldUpdate: false)
     }
 
-    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_Lowercase_Latin1() {
+    func testThatItSets_reachedEndOfHead_WhenDataContainsHead_Lowercase_Latin1() {
         assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</head>", encoding: .isoLatin1)
     }
 
-    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_Capitalized_Latin1() {
+    func testThatItSets_reachedEndOfHead_WhenDataContainsHead_Capitalized_Latin1() {
         assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</Head>", encoding: .isoLatin1)
     }
 
-    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_Uppercase_Latin1() {
+    func testThatItSets_reachedEndOfHead_WhenDataContainsHead_Uppercase_Latin1() {
         assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</HEAD>", encoding: .isoLatin1)
     }
 
-    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_WithSpaces_Latin1() {
+    func testThatItSets_reachedEndOfHead_WhenDataContainsHead_WithSpaces_Latin1() {
         assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</head >", shouldUpdate: false, encoding: .isoLatin1)
     }
 
-    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_Lowercase_ASCII() {
+    func testThatItSets_reachedEndOfHead_WhenDataContainsHead_Lowercase_ASCII() {
         assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</head>", encoding: .ascii)
     }
 
-    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_Capitalized_ASCII() {
+    func testThatItSets_reachedEndOfHead_WhenDataContainsHead_Capitalized_ASCII() {
     assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</Head>", encoding: .ascii)
     }
 
-    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_Uppercase_ASCII() {
+    func testThatItSets_reachedEndOfHead_WhenDataContainsHead_Uppercase_ASCII() {
         assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</HEAD>", encoding: .ascii)
     }
 
-    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_WithSpaces_ASCII() {
+    func testThatItSets_reachedEndOfHead_WhenDataContainsHead_WithSpaces_ASCII() {
         assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</head >", shouldUpdate: false, encoding: .ascii)
     }
     

--- a/WireLinkPreviewTests/MetaStreamContainerTests.swift
+++ b/WireLinkPreviewTests/MetaStreamContainerTests.swift
@@ -29,25 +29,16 @@ class MetaStreamContainerTests: XCTestCase {
         sut = MetaStreamContainer()
     }
 
-    func testThatItAppendsBytes() {
-        // given
-        let first = "First".utf8Data
-        let second = "Second".utf8Data
+    func testThatItAppendsBytes_UTF8() {
+        assertThatItAppendsBytes()
+    }
 
-        // when
-        sut.addData(first)
+    func testThatItAppendsBytes_Latin_1() {
+        assertThatItAppendsBytes(encoding: .isoLatin1)
+    }
 
-        // then
-        XCTAssertEqual(sut.bytes, first)
-        XCTAssertEqual(sut.stringContent, "First")
-
-        // when
-        sut.addData(second)
-
-        // then
-        let expected = "FirstSecond".utf8Data
-        XCTAssertEqual(sut.bytes, expected)
-        XCTAssertEqual(sut.stringContent, "FirstSecond")
+    func testThatItAppendsBytes_ASCII() {
+        assertThatItAppendsBytes(encoding: .ascii)
     }
 
     func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_Lowercase() {
@@ -64,6 +55,38 @@ class MetaStreamContainerTests: XCTestCase {
     
     func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_WithSpaces() {
         assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</head >", shouldUpdate: false)
+    }
+
+    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_Lowercase_Latin1() {
+        assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</head>", encoding: .isoLatin1)
+    }
+
+    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_Capitalized_Latin1() {
+        assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</Head>", encoding: .isoLatin1)
+    }
+
+    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_Uppercase_Latin1() {
+        assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</HEAD>", encoding: .isoLatin1)
+    }
+
+    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_WithSpaces_Latin1() {
+        assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</head >", shouldUpdate: false, encoding: .isoLatin1)
+    }
+
+    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_Lowercase_ASCII() {
+        assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</head>", encoding: .ascii)
+    }
+
+    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_Capitalized_ASCII() {
+    assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</Head>", encoding: .ascii)
+    }
+
+    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_Uppercase_ASCII() {
+        assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</HEAD>", encoding: .ascii)
+    }
+
+    func testThatItSets_rechaedEndOfHead_WhenDataContainsHead_WithSpaces_ASCII() {
+        assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</head >", shouldUpdate: false, encoding: .ascii)
     }
     
     func testThatItExtractsTheHead_whenAllInOneLine() {
@@ -83,12 +106,48 @@ class MetaStreamContainerTests: XCTestCase {
         let html = "<!DOCTYPE html><html lang=\"en\">\n\(head)"
         assertThatItExtractsTheCorrectHead(html, expectedHead: head)
     }
+
+    func testThatItExtractsTheHead_whenAllInOneLine_Latin1() {
+        let head = "<head>header</head>"
+        let html = "<!DOCTYPE html><html lang=\"en\">\(head)"
+        assertThatItExtractsTheCorrectHead(html, expectedHead: head, encoding: .isoLatin1)
+    }
+
+    func testThatItExtractsTheHead_whenOneASeparateLine_Latin1() {
+        let head = "<head>\nheader\n</head>"
+        let html = "<!DOCTYPE html><html lang=\"en\">\n\(head)"
+        assertThatItExtractsTheCorrectHead(html, expectedHead: head, encoding: .isoLatin1)
+    }
+
+    func testThatItExtractsTheHead_whenItHasAttributes_Latin1() {
+        let head = "<head data-network=\"123\">\nheader\n</head>"
+        let html = "<!DOCTYPE html><html lang=\"en\">\n\(head)"
+        assertThatItExtractsTheCorrectHead(html, expectedHead: head, encoding: .isoLatin1)
+    }
+
+    func testThatItExtractsTheHead_whenAllInOneLine_ASCII() {
+        let head = "<head>header</head>"
+        let html = "<!DOCTYPE html><html lang=\"en\">\(head)"
+        assertThatItExtractsTheCorrectHead(html, expectedHead: head, encoding: .ascii)
+    }
+
+    func testThatItExtractsTheHead_whenOneASeparateLine_ASCII() {
+        let head = "<head>\nheader\n</head>"
+        let html = "<!DOCTYPE html><html lang=\"en\">\n\(head)"
+        assertThatItExtractsTheCorrectHead(html, expectedHead: head, encoding: .ascii)
+    }
+
+    func testThatItExtractsTheHead_whenItHasAttributes_ASCII() {
+        let head = "<head data-network=\"123\">\nheader\n</head>"
+        let html = "<!DOCTYPE html><html lang=\"en\">\n\(head)"
+        assertThatItExtractsTheCorrectHead(html, expectedHead: head, encoding: .ascii)
+    }
     
     // MARK: - Helper
     
-    func assertThatItExtractsTheCorrectHead(_ html: String, expectedHead: String, line: UInt = #line) {
+    func assertThatItExtractsTheCorrectHead(_ html: String, expectedHead: String, encoding: String.Encoding = .utf8, line: UInt = #line) {
         // when
-        sut.addData(html.utf8Data)
+        sut.addData(html.data(using: encoding)!)
         
         // then
         XCTAssertTrue(sut.reachedEndOfHead)
@@ -96,11 +155,11 @@ class MetaStreamContainerTests: XCTestCase {
         XCTAssertEqual(head, expectedHead, line: line)
     }
     
-    func assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead(_ head: String, shouldUpdate: Bool = true, line: UInt = #line) {
+    func assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead(_ head: String, shouldUpdate: Bool = true, encoding: String.Encoding = .utf8, line: UInt = #line) {
         // given
-        let first = "First".utf8Data
-        let second = "Head".utf8Data
-        let fourth = "End".utf8Data
+        let first = "First".data(using: encoding)!
+        let second = "Head".data(using: encoding)!
+        let fourth = "End".data(using: encoding)!
         
         // when & then
         sut.addData(first)
@@ -111,7 +170,7 @@ class MetaStreamContainerTests: XCTestCase {
         XCTAssertFalse(sut.reachedEndOfHead, line: line)
         
         // when & then
-        sut.addData(head.utf8Data)
+        sut.addData(head.data(using: encoding)!)
         XCTAssertEqual(sut.reachedEndOfHead, shouldUpdate, line: line)
         
         // when & then
@@ -119,10 +178,25 @@ class MetaStreamContainerTests: XCTestCase {
         XCTAssertEqual(sut.reachedEndOfHead, shouldUpdate, line: line)
     }
 
-}
+    func assertThatItAppendsBytes(file: StaticString = #file, line: UInt = #line, encoding: String.Encoding = .utf8) {
+        // given
+        let first = "First".data(using: encoding)!
+        let second = "Second".data(using: encoding)!
 
-extension String {
-    var utf8Data: Data {
-        return data(using: String.Encoding.utf8)!
+        // when
+        sut.addData(first)
+
+        // then
+        XCTAssertEqual(sut.bytes, first)
+        XCTAssertEqual(sut.stringContent, "First")
+
+        // when
+        sut.addData(second)
+
+        // then
+        let expected = "FirstSecond".data(using: encoding)!
+        XCTAssertEqual(sut.bytes, expected)
+        XCTAssertEqual(sut.stringContent, "FirstSecond")
     }
+
 }

--- a/WireLinkPreviewTests/PreviewDownloaderTests.swift
+++ b/WireLinkPreviewTests/PreviewDownloaderTests.swift
@@ -210,7 +210,7 @@ class PreviewDownloaderTests: XCTestCase {
         let completion: PreviewDownloader.DownloadCompletion = { _ in downloadExpectation.fulfill() }
         let originalRequest = URLRequest(url: URL(string: "www.example.com")!)
         sut.requestOpenGraphData(fromURL: url, completion: completion)
-        sut.processReceivedData("bytes".utf8Data, forTask: mockDataTask, withIdentifier: 0)
+        sut.processReceivedData("bytes".data(using: .utf8)!, forTask: mockDataTask, withIdentifier: 0)
         
         // when
         let response = HTTPURLResponse(

--- a/WireLinkPreviewTests/PreviewDownloaderTests.swift
+++ b/WireLinkPreviewTests/PreviewDownloaderTests.swift
@@ -142,7 +142,7 @@ class PreviewDownloaderTests: XCTestCase {
     
     func testThatItDoesNotCallTheCompletionAndCleansUpIfItReceivesANilError() {
         // given
-        let firstBytes = " <head> ".data(using: String.Encoding.utf8)!
+        let firstBytes = " <head> </head>".data(using: String.Encoding.utf8)!
         let completion: PreviewDownloader.DownloadCompletion = { _ in }
         let taskID = 0
         
@@ -152,7 +152,7 @@ class PreviewDownloaderTests: XCTestCase {
         sut.urlSession(mockSession, task: mockDataTask, didCompleteWithError: nil)
         
         // then
-        XCTAssertEqual(mockDataTask.cancelCallCount, 0)
+        XCTAssertEqual(mockDataTask.cancelCallCount, 1)
         XCTAssertNotNil(sut.completionByURL[url])
         XCTAssertNotNil(sut.containerByTaskID[taskID])
     }
@@ -166,7 +166,25 @@ class PreviewDownloaderTests: XCTestCase {
         
         // when
         sut.requestOpenGraphData(fromURL: url, completion: completion)
+        sut.cancel(task: mockDataTask)
         sut.urlSession(mockSession, task: mockDataTask, didCompleteWithError: error)
+    }
+
+    func testThatItCallsTheCompletionHandlerWhenItDidNotReceiveParsableDataNilError() {
+        // given
+        let firstBytes = Data()
+        let completion: PreviewDownloader.DownloadCompletion = { _ in }
+        let taskID = 0
+
+        // when
+        sut.requestOpenGraphData(fromURL: url, completion: completion)
+        sut.processReceivedData(firstBytes, forTask: mockDataTask, withIdentifier: taskID)
+        sut.urlSession(mockSession, task: mockDataTask, didCompleteWithError: nil)
+
+        // then
+        XCTAssertEqual(mockDataTask.cancelCallCount, 0)
+        XCTAssertNil(sut.completionByURL[url])
+        XCTAssertNil(sut.containerByTaskID[taskID])
     }
     
     func testThatItOverridesTheContentTypeOfTheURLSessionUsedForParsing() {


### PR DESCRIPTION
# What's in this PR?

* There was a bug which prevented the completion handler of the link preview processor being called at all. For link with a non UTF-8 content type the completion handler wasn't invoked. We now try other encodings as well. This issue was discovered as the share extension will not dismiss until the link preview state is `.done`. 
* I'm still thinking about a better way to do this, e.g. checking the content-type header for charset information, as trying multiple encodings also is not the most robust way to handle this case.
* The link which blocked the share extension from dismissing was https://www.thalia.de/shop/home/show/ and the content uses an ISO-8859-1 charset.