### PR TITLE
Create HTML document instead of XML document

### DIFF
--- a/WireLinkPreview/LinkPreviewDetector.swift
+++ b/WireLinkPreview/LinkPreviewDetector.swift
@@ -78,7 +78,7 @@ public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
      - parameter completion: The completion closure called when the link previews (and it's images) have been downloaded.
      */
     public func downloadLinkPreviews(inText text: String, completion : @escaping DetectCompletion) {
-        guard let (url, range) = containedLinks(inText: text).first , !blacklist.isBlacklisted(url) else { return callCompletion(completion, result: []) }
+        guard let (url, range) = containedLinks(inText: text).first, !blacklist.isBlacklisted(url) else { return callCompletion(completion, result: []) }
         previewDownloader.requestOpenGraphData(fromURL: url) { [weak self] openGraphData in
             guard let `self` = self else { return }
             let originalURLString = (text as NSString).substring(with: range)

--- a/WireLinkPreview/OpenGraphScanner.swift
+++ b/WireLinkPreview/OpenGraphScanner.swift
@@ -37,7 +37,7 @@ final class OpenGraphScanner: NSObject {
     }
     
     func parse() {
-        guard let document = try? ONOXMLDocument(string: xmlString, encoding: String.Encoding.utf8.rawValue) else { return }
+        guard let document = try? ONOXMLDocument.htmlDocument(with: xmlString, encoding: String.Encoding.utf8.rawValue) else { return }
         parseXML(document)
         createObjectAndComplete(document)
     }
@@ -76,10 +76,10 @@ final class OpenGraphScanner: NSObject {
 
     private func insertMissingTitleIfNeeded(_ xmlDocument: ONOXMLDocument) {
         guard !contentsByProperty.keys.contains(.title) else { return }
-
-        xmlDocument.enumerateElements(withXPath: "//title", using: { [weak self] (element, _, _) in
+        xmlDocument.enumerateElements(withXPath: "//title", using: { [weak self] (element, _, stop) in
             guard let `self` = self, let value = element?.stringValue() else { return }
             self.addProperty(.title, value: value)
+            stop?.pointee = ObjCBool(true)
         })
     }
 }


### PR DESCRIPTION
# What's in this PR?

In some cases link previews for tweets did not contain the tweet string itself, which was caused by too strict rules when creating an `ONOXMLDocument` from the received html. To avoid this we now use a less strict parsing method `.htmlDocument(with:encoding:)`.