### PR TITLE
Update for changed iTunes metadata

### DIFF
--- a/WireLinkPreviewTests/IntegrationTests.swift
+++ b/WireLinkPreviewTests/IntegrationTests.swift
@@ -94,13 +94,13 @@ class IntegrationTests: XCTestCase {
     }
 
     func testThatItParsesSampleDataiTunes() {
-        let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "website", siteNameString: "iTunes", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
+        let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "music.album", siteNameString: "iTunes", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.iTunesData()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
 
     func testThatItParsesSampleDataiTunesWithoutTitle() {
-        let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "website", siteNameString: "iTunes", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
+        let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "music.album", siteNameString: "iTunes", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.iTunesDataWithoutTitle()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }

--- a/WireLinkPreviewTests/OpenGraphScannerTests.swift
+++ b/WireLinkPreviewTests/OpenGraphScannerTests.swift
@@ -93,6 +93,17 @@ class OpenGraphScannerTests: XCTestCase {
 
         // then
         XCTAssertNotNil(receivedData, line: line)
+        XCTAssertEqual(mockData.expected?.title, receivedData?.title, line: line)
+        XCTAssertEqual(mockData.expected?.type, receivedData?.type, line: line)
+        XCTAssertEqual(mockData.expected?.url, receivedData?.url, line: line)
+        
+        XCTAssertEqual(mockData.expected?.imageUrls ?? [], receivedData?.imageUrls ?? [], line: line)
+        XCTAssertEqual(mockData.expected?.siteName, receivedData?.siteName, line: line)
+        XCTAssertEqual(mockData.expected?.siteNameString, receivedData?.siteNameString, line: line)
+        XCTAssertEqual(mockData.expected?.content, receivedData?.content, line: line)
+        XCTAssertEqual(mockData.expected?.userGeneratedImage, receivedData?.userGeneratedImage, line: line)
+        XCTAssertEqual(mockData.expected?.foursquareMetaData, receivedData?.foursquareMetaData, line: line)
+
         XCTAssertEqual(mockData.expected, receivedData, line: line)
     }
     


### PR DESCRIPTION
It seems at some point iTunes started to return value for `og:type` of the page we are testing. Initially it was probably missing and would fallback to "website". Because this uses real URL tests started failing.