### PR TITLE
Fix failing links

### DIFF
--- a/WireLinkPreviewTests/IntegrationTests.swift
+++ b/WireLinkPreviewTests/IntegrationTests.swift
@@ -94,13 +94,13 @@ class IntegrationTests: XCTestCase {
     }
 
     func testThatItParsesSampleDataiTunes() {
-        let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "music.album", siteNameString: "iTunes", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
+        let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "music.album", siteNameString: "Apple Music", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.iTunesData()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
 
     func testThatItParsesSampleDataiTunesWithoutTitle() {
-        let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "music.album", siteNameString: "iTunes", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
+        let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "music.album", siteNameString: "Apple Music", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.iTunesDataWithoutTitle()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }

--- a/WireLinkPreviewTests/IntegrationTests.swift
+++ b/WireLinkPreviewTests/IntegrationTests.swift
@@ -130,9 +130,8 @@ class IntegrationTests: XCTestCase {
         var result: OpenGraphData?
         sut.requestOpenGraphData(fromURL: URL(string: mockData.urlString)!) { data in
             result = data
-            if (data != nil) {
-                completionExpectation.fulfill()
-            }
+            XCTAssertNotNil(data)
+            completionExpectation.fulfill()
         }
 
         waitForExpectations(timeout: 10, handler: nil)

--- a/WireLinkPreviewTests/MetaStreamContainerTests.swift
+++ b/WireLinkPreviewTests/MetaStreamContainerTests.swift
@@ -142,17 +142,24 @@ class MetaStreamContainerTests: XCTestCase {
         let html = "<!DOCTYPE html><html lang=\"en\">\n\(head)"
         assertThatItExtractsTheCorrectHead(html, expectedHead: head, encoding: .ascii)
     }
+        
+    func testThatItExtractsTheHead_toEndOfString_whenItDoesNotHaveEndTag() {
+        let junk = Array(repeating: "JUNK", count: MetaStreamContainer.fetchLimit).joined(separator: "-")
+        let head = "<head data-network=\"123\">\nheader\n" + junk
+        let html = "<!DOCTYPE html><html lang=\"en\">\n\(head)"
+        assertThatItExtractsTheCorrectHead(html, expectedHead: head, encoding: .ascii)
+    }
     
     // MARK: - Helper
     
-    func assertThatItExtractsTheCorrectHead(_ html: String, expectedHead: String, encoding: String.Encoding = .utf8, line: UInt = #line) {
+    func assertThatItExtractsTheCorrectHead(_ html: String, expectedHead: String, encoding: String.Encoding = .utf8, file: StaticString = #file, line: UInt = #line) {
         // when
         sut.addData(html.data(using: encoding)!)
         
         // then
-        XCTAssertTrue(sut.reachedEndOfHead)
-        guard let head = sut.head else { return XCTFail("Head was nil", line: line) }
-        XCTAssertEqual(head, expectedHead, line: line)
+        XCTAssertTrue(sut.reachedEndOfHead, "Should reach end of head", file: file, line: line)
+        guard let head = sut.head else { return XCTFail("Head was nil", file: file, line: line) }
+        XCTAssertEqual(head, expectedHead, "Should have expected head", file: file, line: line)
     }
     
     func assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead(_ head: String, shouldUpdate: Bool = true, encoding: String.Encoding = .utf8, line: UInt = #line) {


### PR DESCRIPTION
Some tests started failing and it uncovered an issue in the parser. 
Some websites in the wild don’t have the closing </head> tag, so try until we download the full HTML. Even in this case it fails to parse metadata because of missing tag. The fix is to just use the end of data and try to parse what we have instead.