### PR TITLE
Fix: crash when fetching website with malformed contents

### DIFF
--- a/WireLinkPreview.xcodeproj/project.pbxproj
+++ b/WireLinkPreview.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		BFB7B3D21D81ACE300EBD1C5 /* Ono.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF7699871D34F881009C378B /* Ono.framework */; };
 		BFB7B3D41D81AE8100EBD1C5 /* Ono.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = BF7699871D34F881009C378B /* Ono.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		BFF057951D25434E004A2C29 /* WireLinkPreview.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BFF0578A1D25434D004A2C29 /* WireLinkPreview.framework */; };
+		F1202A761FA0830000296B4B /* crash.txt in Resources */ = {isa = PBXBuildFile; fileRef = F1202A751FA0830000296B4B /* crash.txt */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -144,6 +145,7 @@
 		BF7699871D34F881009C378B /* Ono.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Ono.framework; path = Carthage/Build/iOS/Ono.framework; sourceTree = "<group>"; };
 		BFF0578A1D25434D004A2C29 /* WireLinkPreview.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WireLinkPreview.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BFF057941D25434E004A2C29 /* WireLinkPreviewTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WireLinkPreviewTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F1202A751FA0830000296B4B /* crash.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = crash.txt; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -227,6 +229,7 @@
 				BF21CC7A1E925A9E00A874F5 /* wire_head.txt */,
 				BF21CC7B1E925A9E00A874F5 /* yahoo_sports_head.txt */,
 				BF21CC7C1E925A9E00A874F5 /* youtube_head.txt */,
+				F1202A751FA0830000296B4B /* crash.txt */,
 			);
 			name = Fixtures;
 			sourceTree = "<group>";
@@ -419,6 +422,7 @@
 				BF21CC931E925AA300A874F5 /* nytimes_head.txt in Resources */,
 				BF21CC9C1E925AA300A874F5 /* youtube_head.txt in Resources */,
 				BF21CC921E925AA300A874F5 /* medium_head.txt in Resources */,
+				F1202A761FA0830000296B4B /* crash.txt in Resources */,
 				BF21CC941E925AA300A874F5 /* polygon_head.txt in Resources */,
 				BF21CC9B1E925AA300A874F5 /* yahoo_sports_head.txt in Resources */,
 			);

--- a/WireLinkPreview/MetaStreamContainer.swift
+++ b/WireLinkPreview/MetaStreamContainer.swift
@@ -32,10 +32,17 @@ final class MetaStreamContainer {
     
     var head: String? {
         guard let content = stringContent else { return nil }
-        guard let startRange = content.range(of: OpenGraphXMLNode.headStart.rawValue) else { return nil }
+        var startBound = content.range(of: OpenGraphXMLNode.headStart.rawValue)?.lowerBound ??
+                           content.range(of: OpenGraphXMLNode.headStartNoAttributes.rawValue)?.lowerBound ??
+                           content.startIndex
         
         let upperBound = content.range(of: OpenGraphXMLNode.headEnd.rawValue)?.upperBound ?? content.endIndex
-        let result = content.substring(with: startRange.lowerBound..<upperBound)
+
+        if startBound >= upperBound {
+            startBound = content.startIndex
+        }
+
+        let result = content.substring(with: startBound..<upperBound)
         return result
     }
     

--- a/WireLinkPreview/OpenGraphDataTypes.swift
+++ b/WireLinkPreview/OpenGraphDataTypes.swift
@@ -25,7 +25,8 @@ enum OpenGraphAttribute: String {
 }
 
 enum OpenGraphXMLNode: String {
-    case headStart = "<head"
+    case headStart = "<head "
+    case headStartNoAttributes = "<head>"
     case headEnd = "</head>"
 }
 

--- a/WireLinkPreviewTests/IntegrationTests.swift
+++ b/WireLinkPreviewTests/IntegrationTests.swift
@@ -44,6 +44,12 @@ class IntegrationTests: XCTestCase {
         let mockData = OpenGraphMockDataProvider.washingtonPostData()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
+
+    func testThatItParsesSampleDataWithoutCrash() {
+        let expectation = OpenGraphDataExpectation(numberOfImages: 30, type: "article", siteNameString: "iPhone Photography School", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
+        let mockData = OpenGraphMockDataProvider.crashingData()
+        assertThatItCanParseSampleData(mockData, expected: expectation)
+    }
     
     func testThatItParsesSampleDataYouTube() {
         let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "video", siteNameString: "YouTube", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
@@ -130,7 +136,7 @@ class IntegrationTests: XCTestCase {
         var result: OpenGraphData?
         sut.requestOpenGraphData(fromURL: URL(string: mockData.urlString)!) { data in
             result = data
-            XCTAssertNotNil(data)
+            XCTAssertNotNil(data, line: line)
             completionExpectation.fulfill()
         }
 
@@ -140,12 +146,12 @@ class IntegrationTests: XCTestCase {
         }
         
         // then
-        XCTAssertEqual(data.content != nil, expected.hasDescription, line: line)
-        XCTAssertEqual(data.foursquareMetaData != nil, expected.hasFoursquareMetaData, line: line)
-        XCTAssertEqual(data.type, expected.type, line: line)
-        XCTAssertEqual(data.siteNameString, expected.siteNameString, line: line)
-        XCTAssertEqual(data.userGeneratedImage, expected.userGeneratedImage, line: line)
-        XCTAssertTrue(data.imageUrls.count == expected.numberOfImages, line: line)
+        XCTAssertEqual(data.content != nil, expected.hasDescription, expected.hasDescription ? "Should have description" : "Should not have description", line: line)
+        XCTAssertEqual(data.foursquareMetaData != nil, expected.hasFoursquareMetaData, expected.hasFoursquareMetaData ? "Should have Foursquare metadata" : "Should not have Foursquare metadata", line: line)
+        XCTAssertEqual(data.type, expected.type, "Type should be \(expected.type ?? "nil"), found:\(data.type)", line: line)
+        XCTAssertEqual(data.siteNameString, expected.siteNameString, "Site name should be \(expected.siteNameString ?? "nil"), found: \(data.siteNameString ?? "nil")", line: line)
+        XCTAssertEqual(data.userGeneratedImage, expected.userGeneratedImage, "User generated image should match", line: line)
+        XCTAssertTrue(data.imageUrls.count == expected.numberOfImages, "Should have \(expected.numberOfImages) images, found:\(data.imageUrls.count)",line: line)
     }
     
 }

--- a/WireLinkPreviewTests/MetaStreamContainerTests.swift
+++ b/WireLinkPreviewTests/MetaStreamContainerTests.swift
@@ -94,6 +94,23 @@ class MetaStreamContainerTests: XCTestCase {
         let html = "<!DOCTYPE html><html lang=\"en\">\(head)"
         assertThatItExtractsTheCorrectHead(html, expectedHead: head)
     }
+
+    func testThatItExtractsTheHead_whenHeadStartIsMissing() {
+        let html = "<!DOCTYPE html><html lang=\"en\">header</head>"
+        assertThatItExtractsTheCorrectHead(html, expectedHead: html)
+    }
+
+    func testThatItExtractsTheHead_whenHeadStartIsMissingButContainsHeader() {
+        let html = "<!DOCTYPE html><html lang=\"en\"><header>some</header>header</head>"
+        assertThatItExtractsTheCorrectHead(html, expectedHead: html)
+    }
+
+    func testThatItExtractsTheHead_whenHeadStartIsAfterEnd() {
+        let head = "<head>"
+        let body = "<!DOCTYPE html><html lang=\"en\">header</head>"
+        let html = body + head
+        assertThatItExtractsTheCorrectHead(html, expectedHead: body)
+    }
     
     func testThatItExtractsTheHead_whenOneASeparateLine() {
         let head = "<head>\nheader\n</head>"

--- a/WireLinkPreviewTests/OpenGraphMockDataProvider.swift
+++ b/WireLinkPreviewTests/OpenGraphMockDataProvider.swift
@@ -137,6 +137,23 @@ class OpenGraphMockDataProvider: NSObject {
         )
     }
 
+    static func crashingData() -> OpenGraphMockData {
+        let expected = OpenGraphData(
+            title: "The 7 Best iPhone Apps That Turn Photos Into Drawings",
+            type: "article",
+            url: "https://iphonephotographyschool.com/apps-that-turn-photos-into-drawings/",
+            imageUrls: ["https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iPhone-Apps-That-Turn-Photos-Into-Drawings-1.jpg"],
+            siteName: "iPhone Photography School",
+            description: "Discover 7 fantastic iPhone apps that turn photos into drawings and sketches. Get creative and turn your photos into works of art in seconds!"
+        )
+
+        return OpenGraphMockData(
+            head: fixtureWithName("crash"),
+            expected: expected,
+            urlString: expected.url
+        )
+    }
+
     static func instagramData() -> OpenGraphMockData {
         let expected = OpenGraphData(
             title: "Instagram photo by Silvan Dähn • Aug 5, 2015 at 4:27pm UTC",

--- a/WireLinkPreviewTests/crash.txt
+++ b/WireLinkPreviewTests/crash.txt
@@ -1,0 +1,162 @@
+<!DOCTYPE html><title>The 7 Best iPhone Apps That Turn Photos Into Drawings</title><meta charset="UTF-8"><meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0,target-densitydpi=device-dpi, user-scalable=no">
+<!-- This site is optimized with the Yoast SEO plugin v4.0.2 - https://yoast.com/wordpress/plugins/seo/ -->
+<meta name="description" content="Discover 7 fantastic iPhone apps that turn photos into drawings and sketches. Get creative and turn your photos into works of art in seconds!"/>
+<meta name="robots" content="noodp"/>
+<link rel="canonical" href="https://iphonephotographyschool.com/apps-that-turn-photos-into-drawings/" />
+<meta property="og:locale" content="en_US" />
+<meta property="og:type" content="article" />
+<meta property="og:title" content="The 7 Best iPhone Apps That Turn Photos Into Drawings" />
+<meta property="og:description" content="Discover 7 fantastic iPhone apps that turn photos into drawings and sketches. Get creative and turn your photos into works of art in seconds!" />
+<meta property="og:url" content="https://iphonephotographyschool.com/apps-that-turn-photos-into-drawings/" />
+<meta property="og:site_name" content="iPhone Photography School" />
+<meta property="article:publisher" content="https://www.facebook.com/iPhonePS" />
+<meta property="article:tag" content="Painterly iPhoneography" />
+<meta property="article:tag" content="Photo Apps" />
+<meta property="article:tag" content="Photo Editing" />
+<meta property="article:section" content="Photo Editing" />
+<meta property="article:published_time" content="2017-03-16T00:30:13-07:00" />
+<meta property="article:modified_time" content="2017-03-17T07:47:21-07:00" />
+<meta property="og:updated_time" content="2017-03-17T07:47:21-07:00" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iPhone-Apps-That-Turn-Photos-Into-Drawings-1.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iPhone-Apps-That-Turn-Photos-Into-Drawings-2.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iPhone-Apps-That-Turn-Photos-Into-Drawings-3.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/Artomaton-iPhone-App-That-Turns-Photos-Into-Drawings-14.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/Artomaton-iPhone-App-That-Turns-Photos-Into-Drawings-15.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iPhone-Apps-That-Turn-Photos-Into-Drawings-4.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iPhone-Apps-That-Turn-Photos-Into-Drawings-31.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/Enlight-iPhone-App-That-Turns-Photos-Into-Drawings-16.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/Enlight-iPhone-App-That-Turns-Photos-Into-Drawings-17.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/Enlight-iPhone-App-That-Turns-Photos-Into-Drawings-18.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iPhone-Apps-That-Turn-Photos-Into-Drawings-5.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/Handy-Photo-iPhone-App-That-Turns-Photos-Into-Drawings-19.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/Handy-Photo-iPhone-App-That-Turns-Photos-Into-Drawings-20.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/Handy-Photo-iPhone-App-That-Turns-Photos-Into-Drawings-6.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iPhone-Apps-That-Turn-Photos-Into-Drawings-7.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iColorama-S-iPhone-App-That-Turns-Photos-Into-Drawings-21.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iColorama-S-iPhone-App-That-Turns-Photos-Into-Drawings-22.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iColorama-S-iPhone-App-That-Turns-Photos-Into-Drawings-23.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iPhone-Apps-That-Turn-Photos-Into-Drawings-8.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/Imaengine-Vector-Camera-iPhone-App-That-Turns-Photos-Into-Drawings-24.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iPhone-Apps-That-Turn-Photos-Into-Drawings-9.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iPhone-Apps-That-Turn-Photos-Into-Drawings-10.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/Perfect-Image-iPhone-App-That-Turns-Photos-Into-Drawings-25.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iPhone-Apps-That-Turn-Photos-Into-Drawings-11.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iPhone-Apps-That-Turn-Photos-Into-Drawings-12.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/Prisma-iPhone-App-That-Turns-Photos-Into-Drawings-26.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iPhone-Apps-That-Turn-Photos-Into-Drawings-13.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/Prisma-iPhone-App-That-Turns-Photos-Into-Drawings-27.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iPhone-Apps-That-Turn-Photos-Into-Drawings-30.jpg" />
+<meta property="og:image" content="https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iPhone-Apps-That-Turn-Photos-Into-Drawings-28.jpg" />
+<!-- / Yoast SEO plugin. -->
+
+<link rel='dns-prefetch' href='//ajax.googleapis.com' />
+<link rel='dns-prefetch' href='//secure.iphonephotographyschool.com' />
+<link rel='dns-prefetch' href='//s.w.org' />
+<link rel="alternate" type="application/rss+xml" title="iPhone Photography School &raquo; Feed" href="https://iphonephotographyschool.com/feed/" />
+<link rel="alternate" type="application/rss+xml" title="iPhone Photography School &raquo; Comments Feed" href="https://iphonephotographyschool.com/comments/feed/" />
+<link rel="alternate" type="application/rss+xml" title="iPhone Photography School &raquo; The 7 Best iPhone Apps That Turn Your Photos Into Drawings Comments Feed" href="https://iphonephotographyschool.com/apps-that-turn-photos-into-drawings/feed/" />
+<script type="text/javascript">
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+</script>
+<style type="text/css">
+xxxxxxxxxxxxxx
+xxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxx
+x
+</style>
+<link rel='stylesheet' id='iphone-photography-school-css'  href='https://iphonephotographyschool.com/wp-content/themes/ips-theme/style.css?ver=8.23' type='text/css' media='all' />
+<script type='text/javascript' src='https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js'></script>
+<script type='text/javascript' src='https://iphonephotographyschool.com/wp-content/plugins/wp-retina-2x/js/picturefill.min.js?ver=3.0.2'></script>
+<script type='text/javascript' src='https://iphonephotographyschool.com/wp-content/themes/ips-theme/lib/js/velocity.min.js?ver=4.8.2'></script>
+<script type='text/javascript' src='//iphonephotographyschool.com/wp-content/themes/ips-theme/lib/js/responsive-menu.js?ver=4.8.2'></script>
+<script type='text/javascript' src='//secure.iphonephotographyschool.com/js/utm-tracking.js?ver=2.8'></script>
+<script type='text/javascript' src='https://iphonephotographyschool.com/wp-content/themes/ips-theme/lib/js/navigation.js?ver=2.1'></script>
+<script type='text/javascript' src='https://iphonephotographyschool.com/wp-content/themes/ips-theme/lib/js/global.js?ver=1.12'></script>
+<script type='text/javascript' src='https://iphonephotographyschool.com/wp-content/themes/ips-theme/lib/js/welcome.js?ver=42'></script>
+<script type='text/javascript' src='https://iphonephotographyschool.com/wp-content/themes/ips-theme/lib/js/consumption_tracking.js?ver=3'></script>
+<script type='text/javascript' src='https://iphonephotographyschool.com/wp-content/themes/ips-theme/lib/js/ouibounce.js?ver=1'></script>
+<script type='text/javascript' src='https://iphonephotographyschool.com/wp-content/themes/ips-theme/lib/js/share.js?ver=4.8.2'></script>
+<script type='text/javascript' src='https://iphonephotographyschool.com/wp-content/themes/ips-theme/lib/js/pushnotifs.js?ver=1.1'></script>
+<link rel='https://api.w.org/' href='https://iphonephotographyschool.com/wp-json/' />
+<link rel="EditURI" type="application/rsd+xml" title="RSD" href="https://iphonephotographyschool.com/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="https://iphonephotographyschool.com/wp-includes/wlwmanifest.xml" />
+<link rel='shortlink' href='https://iphonephotographyschool.com/?p=65983' />
+<link rel="alternate" type="application/json+oembed" href="https://iphonephotographyschool.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fiphonephotographyschool.com%2Fapps-that-turn-photos-into-drawings%2F" />
+<link rel="alternate" type="text/xml+oembed" href="https://iphonephotographyschool.com/wp-json/oembed/1.0/embed?url=https%3A%2F%2Fiphonephotographyschool.com%2Fapps-that-turn-photos-into-drawings%2F&#038;format=xml" />
+<style>
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+</style>
+<link rel="Shortcut Icon" href="https://iphonephotographyschool.com/wp-content/themes/genesis/images/favicon.ico?v=2" type="image/x-icon" />
+<link rel="apple-touch-icon" sizes="57x57" href="/icons/apple-touch-icon-57x57.png?v=2">
+<link rel="apple-touch-icon" sizes="114x114" href="/icons/apple-touch-icon-114x114.png?v=2">
+<link rel="apple-touch-icon" sizes="72x72" href="/icons/apple-touch-icon-72x72.png?v=2">
+<link rel="apple-touch-icon" sizes="144x144" href="/icons/apple-touch-icon-144x144.png?v=2">
+<link rel="apple-touch-icon" sizes="60x60" href="/icons/apple-touch-icon-60x60.png?v=2">
+<link rel="apple-touch-icon" sizes="120x120" href="/icons/apple-touch-icon-120x120.png?v=2">
+<link rel="apple-touch-icon" sizes="76x76" href="/icons/apple-touch-icon-76x76.png?v=2">
+<link rel="apple-touch-icon" sizes="152x152" href="/icons/apple-touch-icon-152x152.png?v=2">
+<link rel="icon" type="image/png" href="/icons/favicon-196x196.png?v=2" sizes="196x196">
+<link rel="icon" type="image/png" href="/icons/favicon-160x160.png?v=2" sizes="160x160">
+<link rel="icon" type="image/png" href="/icons/favicon-96x96.png?v=2" sizes="96x96">
+<link rel="icon" type="image/png" href="/icons/favicon-16x16.png?v=2" sizes="16x16">
+<link rel="icon" type="image/png" href="/icons/favicon-32x32.png?v=2" sizes="32x32">
+<link rel="mask-icon" href="/icons/touch-bar-icon.svg" color="#212121">
+
+<meta name="msapplication-TileColor" content="#00aba9">
+<meta name="msapplication-TileImage" content="/icons/mstile-144x144.png">
+xxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+<script type="application/ld+json">
+x
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+x
+x
+</script>
+<link rel="manifest" href="/wp-content/themes/ips-theme/lib/manifest.json">
+<script src="https://cdn.onesignal.com/sdks/OneSignalSDK.js" async></script>
+
+</head>
+<body class="post-template-default single single-post postid-65983 single-format-standard nolayout" itemscope="itemscope" itemtype="http://schema.org/WebPage"><div class="site-container"><div class="top-line">
+


### PR DESCRIPTION
The problem was that opening tag `<head>` was missing, but `</head>` was present. We were handling this case, but the crash was triggered because there also was `<header>` tag which was falsely identified becase it starts with `<head`. The fix is to search for both variants of the tag (with attributes and without) and also double check to make sure `<head>` is not after `</head>`.