### PR TITLE
Link previews not shown correctly and not clickable (link previews)

### DIFF
--- a/WireLinkPreview/LinkPreviewTypes.swift
+++ b/WireLinkPreview/LinkPreviewTypes.swift
@@ -24,15 +24,17 @@ import Foundation
     
     open let originalURLString: String
     open let permanentURL: URL?
+    open let resolvedURL: URL?
     open let characterOffsetInText: Int
     open var imageURLs = [URL]()
     open var imageData = [Data]()
     
     public typealias DownloadCompletion = (_ successful: Bool) -> Void
     
-    public init(originalURLString: String, permamentURLString: String, offset: Int) {
+    public init(originalURLString: String, permamentURLString: String, resolvedURLString: String, offset: Int) {
         self.originalURLString = originalURLString
         permanentURL = URL(string: permamentURLString)
+        resolvedURL = URL(string: resolvedURLString)
         characterOffsetInText = offset
         super.init()
     }

--- a/WireLinkPreview/LinkPreviewTypes.swift
+++ b/WireLinkPreview/LinkPreviewTypes.swift
@@ -31,9 +31,9 @@ import Foundation
     
     public typealias DownloadCompletion = (_ successful: Bool) -> Void
     
-    public init(originalURLString: String, permamentURLString: String, resolvedURLString: String, offset: Int) {
+    public init(originalURLString: String, permanentURLString: String, resolvedURLString: String, offset: Int) {
         self.originalURLString = originalURLString
-        permanentURL = URL(string: permamentURLString)
+        permanentURL = URL(string: permanentURLString)
         resolvedURL = URL(string: resolvedURLString)
         characterOffsetInText = offset
         super.init()

--- a/WireLinkPreview/OpenGraphData.swift
+++ b/WireLinkPreview/OpenGraphData.swift
@@ -23,6 +23,7 @@ public struct OpenGraphData {
     let title: String
     let type: String
     let url: String
+    let resolvedURL: String
     let imageUrls: [String]
 
     let siteName: OpenGraphSiteName
@@ -32,10 +33,11 @@ public struct OpenGraphData {
     
     var foursquareMetaData: FoursquareMetaData?
     
-    init(title: String, type: String?, url: String, imageUrls: [String], siteName: String? = nil, description: String? = nil, userGeneratedImage: Bool = false) {
+    init(title: String, type: String?, url: String, resolvedURL: String, imageUrls: [String], siteName: String? = nil, description: String? = nil, userGeneratedImage: Bool = false) {
         self.title = title
         self.type = type ?? OpenGraphTypeType.website.rawValue
         self.url = url
+        self.resolvedURL = resolvedURL
         self.imageUrls = imageUrls
         self.siteNameString = siteName
         self.siteName = siteName.map { OpenGraphSiteName(string: $0) ?? .other } ?? .other
@@ -71,7 +73,7 @@ extension OpenGraphData {
     
     typealias PropertyMapping = [OpenGraphPropertyType: String]
     
-    init?(propertyMapping mapping: PropertyMapping, images: [String]) {
+    init?(propertyMapping mapping: PropertyMapping, resolvedURL: URL, images: [String]) {
         guard let title = mapping[.title],
             let url = mapping[.url] else { return nil }
      
@@ -79,6 +81,7 @@ extension OpenGraphData {
             title: title,
             type: mapping[.type],
             url: url,
+            resolvedURL: resolvedURL.absoluteString,
             imageUrls: images,
             siteName: mapping[.siteName],
             description: mapping[.description],
@@ -108,7 +111,7 @@ public func ==(lhs: FoursquareMetaData, rhs: FoursquareMetaData) -> Bool {
 
 extension Article {
     public convenience init(openGraphData: OpenGraphData, originalURLString: String, offset: Int) {
-        self.init(originalURLString: originalURLString, permamentURLString: openGraphData.url, offset: offset)
+        self.init(originalURLString: originalURLString, permamentURLString: openGraphData.url, resolvedURLString: openGraphData.resolvedURL, offset: offset)
         title = openGraphData.title
         summary = openGraphData.content
         guard let imageURL = openGraphData.imageUrls.flatMap(URL.init).first else { return }
@@ -120,7 +123,7 @@ extension FoursquareLocation {
     public convenience init?(openGraphData: OpenGraphData, originalURLString: String, offset: Int) {
         guard openGraphData.type  == OpenGraphTypeType.foursquare.rawValue && openGraphData.siteName == .foursquare else { return nil }
         
-        self.init(originalURLString: originalURLString, permamentURLString: openGraphData.url, offset: offset)
+        self.init(originalURLString: originalURLString, permamentURLString: openGraphData.url, resolvedURLString: openGraphData.resolvedURL, offset: offset)
         title = openGraphData.title
         subtitle = openGraphData.content
         longitude = openGraphData.foursquareMetaData?.longitude
@@ -133,7 +136,7 @@ extension FoursquareLocation {
 extension InstagramPicture {
     public convenience init?(openGraphData: OpenGraphData, originalURLString: String, offset: Int) {
         guard openGraphData.type == OpenGraphTypeType.instagram.rawValue && openGraphData.siteName == .instagram else { return nil }
-        self.init(originalURLString: originalURLString, permamentURLString: openGraphData.url, offset: offset)
+        self.init(originalURLString: originalURLString, permamentURLString: openGraphData.url, resolvedURLString: openGraphData.resolvedURL, offset: offset)
         title = openGraphData.title
         subtitle = openGraphData.content
         guard let imageURL = openGraphData.imageUrls.flatMap(URL.init).first else { return }
@@ -145,7 +148,7 @@ extension TwitterStatus {
 
     public convenience init?(openGraphData: OpenGraphData, originalURLString: String, offset: Int) {
         guard openGraphData.type == OpenGraphTypeType.article.rawValue && openGraphData.siteName == .twitter else { return nil }
-        self.init(originalURLString: originalURLString, permamentURLString: openGraphData.url, offset: offset)
+        self.init(originalURLString: originalURLString, permamentURLString: openGraphData.url, resolvedURLString: openGraphData.resolvedURL, offset: offset)
         
         message = tweetContentFromOpenGraphData(openGraphData)
         author = tweetAuthorFromOpenGraphData(openGraphData)

--- a/WireLinkPreview/OpenGraphData.swift
+++ b/WireLinkPreview/OpenGraphData.swift
@@ -111,7 +111,7 @@ public func ==(lhs: FoursquareMetaData, rhs: FoursquareMetaData) -> Bool {
 
 extension Article {
     public convenience init(openGraphData: OpenGraphData, originalURLString: String, offset: Int) {
-        self.init(originalURLString: originalURLString, permamentURLString: openGraphData.url, resolvedURLString: openGraphData.resolvedURL, offset: offset)
+        self.init(originalURLString: originalURLString, permanentURLString: openGraphData.url, resolvedURLString: openGraphData.resolvedURL, offset: offset)
         title = openGraphData.title
         summary = openGraphData.content
         guard let imageURL = openGraphData.imageUrls.flatMap(URL.init).first else { return }
@@ -123,7 +123,7 @@ extension FoursquareLocation {
     public convenience init?(openGraphData: OpenGraphData, originalURLString: String, offset: Int) {
         guard openGraphData.type  == OpenGraphTypeType.foursquare.rawValue && openGraphData.siteName == .foursquare else { return nil }
         
-        self.init(originalURLString: originalURLString, permamentURLString: openGraphData.url, resolvedURLString: openGraphData.resolvedURL, offset: offset)
+        self.init(originalURLString: originalURLString, permanentURLString: openGraphData.url, resolvedURLString: openGraphData.resolvedURL, offset: offset)
         title = openGraphData.title
         subtitle = openGraphData.content
         longitude = openGraphData.foursquareMetaData?.longitude
@@ -136,7 +136,7 @@ extension FoursquareLocation {
 extension InstagramPicture {
     public convenience init?(openGraphData: OpenGraphData, originalURLString: String, offset: Int) {
         guard openGraphData.type == OpenGraphTypeType.instagram.rawValue && openGraphData.siteName == .instagram else { return nil }
-        self.init(originalURLString: originalURLString, permamentURLString: openGraphData.url, resolvedURLString: openGraphData.resolvedURL, offset: offset)
+        self.init(originalURLString: originalURLString, permanentURLString: openGraphData.url, resolvedURLString: openGraphData.resolvedURL, offset: offset)
         title = openGraphData.title
         subtitle = openGraphData.content
         guard let imageURL = openGraphData.imageUrls.flatMap(URL.init).first else { return }
@@ -148,7 +148,7 @@ extension TwitterStatus {
 
     public convenience init?(openGraphData: OpenGraphData, originalURLString: String, offset: Int) {
         guard openGraphData.type == OpenGraphTypeType.article.rawValue && openGraphData.siteName == .twitter else { return nil }
-        self.init(originalURLString: originalURLString, permamentURLString: openGraphData.url, resolvedURLString: openGraphData.resolvedURL, offset: offset)
+        self.init(originalURLString: originalURLString, permanentURLString: openGraphData.url, resolvedURLString: openGraphData.resolvedURL, offset: offset)
         
         message = tweetContentFromOpenGraphData(openGraphData)
         author = tweetAuthorFromOpenGraphData(openGraphData)

--- a/WireLinkPreview/OpenGraphScanner.swift
+++ b/WireLinkPreview/OpenGraphScanner.swift
@@ -65,7 +65,7 @@ final class OpenGraphScanner: NSObject {
     private func createObjectAndComplete(_ xmlDocument: ONOXMLDocument) {
         insertMissingUrlIfNeeded()
         insertMissingTitleIfNeeded(xmlDocument)
-        let data = OpenGraphData(propertyMapping: contentsByProperty, images: images)
+        let data = OpenGraphData(propertyMapping: contentsByProperty, resolvedURL: originalURL, images: images)
         completion(data)
     }
 

--- a/WireLinkPreviewTests/OpenGraphDataTests.swift
+++ b/WireLinkPreviewTests/OpenGraphDataTests.swift
@@ -31,7 +31,7 @@ class OpenGraphDataTests: XCTestCase {
         let images = ["www.example.com/image"]
         
         // when
-        guard let sut = OpenGraphData(propertyMapping: mapping, images: images) else { return XCTFail() }
+        guard let sut = OpenGraphData(propertyMapping: mapping, resolvedURL: URL(string: url)!, images: images) else { return XCTFail() }
         
         // then
         XCTAssertEqual(sut.title, title)
@@ -52,7 +52,7 @@ class OpenGraphDataTests: XCTestCase {
         let images = ["www.example.com/image"]
 
         // when
-        let sut = OpenGraphData(propertyMapping: mapping, images: images)
+        let sut = OpenGraphData(propertyMapping: mapping, resolvedURL: URL(string: url)!, images: images)
 
         // then
         XCTAssertNotNil(sut)
@@ -66,7 +66,7 @@ class OpenGraphDataTests: XCTestCase {
         let images = ["www.example.com/image"]
         
         // when
-        let sut = OpenGraphData(propertyMapping: mapping, images: images)
+        let sut = OpenGraphData(propertyMapping: mapping, resolvedURL: URL(string: "www.example.com/image")!, images: images)
         
         // then
         XCTAssertNil(sut)
@@ -164,7 +164,7 @@ class OpenGraphDataTests: XCTestCase {
         let images = ["www.example.com/image"]
         
         // when
-        guard let sut = OpenGraphData(propertyMapping: mapping, images: images) else { return XCTFail(line: line) }
+        guard let sut = OpenGraphData(propertyMapping: mapping, resolvedURL: URL(string: url)!, images: images) else { return XCTFail(line: line) }
         
         XCTAssertEqual(sut.siteName, expected, line: line)
         XCTAssertEqual(sut.siteNameString, siteNameString, line: line)

--- a/WireLinkPreviewTests/OpenGraphMockDataProvider.swift
+++ b/WireLinkPreviewTests/OpenGraphMockDataProvider.swift
@@ -35,6 +35,7 @@ class OpenGraphMockDataProvider: NSObject {
             title: "ericasadun on Twitter",
             type: "article",
             url: "https://twitter.com/ericasadun/status/743868311843151872",
+            resolvedURL: "https://twitter.com/ericasadun/status/743868311843151872",
             imageUrls: ["https://pbs.twimg.com/profile_images/292927387/dogbert-e_400x400.png"],
             siteName: "Twitter",
             description: "“`lazy var` doesn't use dispatch_once/not thread-safe w/o synch'n. Only global&static properties init w/ dispatchonceish mechanism- @jckarter”"
@@ -53,6 +54,7 @@ class OpenGraphMockDataProvider: NSObject {
             title: "Ayaka Nonaka on Twitter",
             type: "article",
             url: "https://twitter.com/ayanonagon/status/749726072623685632",
+            resolvedURL: "https://twitter.com/ayanonagon/status/749726072623685632",
             imageUrls: ["https://pbs.twimg.com/media/CmeP2R6VIAAMx2N.jpg:large", "https://pbs.twimg.com/media/CmeP2R5UMAA_1fB.jpg:large", "https://pbs.twimg.com/media/CmeP2R6UIAAHT1t.jpg:large", "https://pbs.twimg.com/media/CmeP2T4UIAA5pNt.jpg:large"],
             siteName: "Twitter",
             description: "“Hello from Lake Tahoe. Happy weekend everyone! ✌🏼️💙❤️”",
@@ -72,6 +74,7 @@ class OpenGraphMockDataProvider: NSObject {
             title: "NETA Mexican Street Food",
             type: "playfoursquare:venue",
             url: "https://foursquare.com/neta_msf",
+            resolvedURL: "https://foursquare.com/neta_msf",
             imageUrls: ["https://irs0.4sqi.net/img/general/600x600/119241531_vEv_57iCz-SX9nKwMsd0GovpEA1gKtNAICRsah7GKjg.jpg", "https://irs3.4sqi.net/img/general/600x600/119241531__mAWGX94algkPbGcxKXYEqMAk4Vso70GkTWGdi-UTAA.jpg", "https://irs0.4sqi.net/img/general/600x600/119241531_b56QzEzT2AeqiFiAz5yzAvzMVkJv-TtuAchMcbuD5hk.jpg", "https://irs1.4sqi.net/img/general/600x600/119241531_aCFVIfqXAUOBJr1ixU8usw-sFxIBCz-zVNeSCcm4N74.jpg"],
             siteName: "Foursquare",
             description: "Burrito-Imbiss in Berlin, Berlin"
@@ -91,6 +94,7 @@ class OpenGraphMockDataProvider: NSObject {
             title: "The ultimate Apple I/O death chart",
             type: "article",
             url: "http://www.theverge.com/2016/6/29/12054410/apple-tech-death-chart-headphone-jack-ports-usb-c",
+            resolvedURL: "http://www.theverge.com/2016/6/29/12054410/apple-tech-death-chart-headphone-jack-ports-usb-c",
             imageUrls: ["https://cdn0.vox-cdn.com/thumbor/eCXqqjnIBNh9YQxtkfu5EofTMO8=/0x134:1500x978/1600x900/cdn0.vox-cdn.com/uploads/chorus_image/image/49985217/imac_ports_large.0.jpg"],
             siteName: "The Verge",
             description: "The internet has been ablaze the past few weeks about Apple potentially removing the headphone jack from the next iPhone — a move that’s been heavily rumored for months, and has everything from..."
@@ -108,6 +112,7 @@ class OpenGraphMockDataProvider: NSObject {
             title: "Last Week Tonight with John Oliver: Brexit (HBO)",
             type: "video",
             url: "https://www.youtube.com/watch?v=iAgKHSNqxa8",
+            resolvedURL: "https://www.youtube.com/watch?v=iAgKHSNqxa8",
             imageUrls: ["https://i.ytimg.com/vi/iAgKHSNqxa8/maxresdefault.jpg"],
             siteName: "YouTube",
             description: "Britain could soon vote to leave the European Union. John Oliver enlists a barbershop quartet to propose a smarter option. Connect with Last Week Tonight onl..."
@@ -125,6 +130,7 @@ class OpenGraphMockDataProvider: NSObject {
             title: "What's it like to drive with Tesla's Autopilot and how does it work?",
             type: "article",
             url: "http://www.theguardian.com/technology/2016/jul/01/tesla-autopilot-model-s-crash-how-does-it-work",
+            resolvedURL: "http://www.theguardian.com/technology/2016/jul/01/tesla-autopilot-model-s-crash-how-does-it-work",
             imageUrls: ["https://i.guim.co.uk/img/media/7a8eb8b3e9768f03fd56b1f38f3a4bbacc2f4521/0_115_3500_2102/3500.jpg?w=1200&h=630&q=55&auto=format&usm=12&fit=crop&bm=normal&ba=bottom%2Cleft&blend64=aHR0cHM6Ly91cGxvYWRzLmd1aW0uY28udWsvMjAxNi8wNS8yNS9vdmVybGF5LWxvZ28tMTIwMC05MF9vcHQucG5n&s=361fd974e61775119c65c52997274245"],
             siteName: "the Guardian",
             description: "Tesla’s Autopilot is in the spotlight after a fatal crash. Samuel Gibbs used it when he drove to France in a Model S – here’s how he found the experience of driver assistance"
@@ -142,6 +148,7 @@ class OpenGraphMockDataProvider: NSObject {
             title: "The 7 Best iPhone Apps That Turn Photos Into Drawings",
             type: "article",
             url: "https://iphonephotographyschool.com/apps-that-turn-photos-into-drawings/",
+            resolvedURL: "https://iphonephotographyschool.com/apps-that-turn-photos-into-drawings/",
             imageUrls: ["https://cdn.iphonephotographyschool.com/wp-content/uploads/2017/03/iPhone-Apps-That-Turn-Photos-Into-Drawings-1.jpg"],
             siteName: "iPhone Photography School",
             description: "Discover 7 fantastic iPhone apps that turn photos into drawings and sketches. Get creative and turn your photos into works of art in seconds!"
@@ -159,6 +166,7 @@ class OpenGraphMockDataProvider: NSObject {
             title: "Instagram photo by Silvan Dähn • Aug 5, 2015 at 4:27pm UTC",
             type: "instapp:photo",
             url: "https://www.instagram.com/p/6AiRp5TOXB/",
+            resolvedURL: "https://www.instagram.com/p/6AiRp5TOXB/",
             imageUrls: ["https://scontent-frt3-1.cdninstagram.com/t51.2885-15/s750x750/sh0.08/e35/11809632_1741377449423046_2075339609_n.jpg?ig_cache_key=MTA0NDk4NTg2MDM0NzE5Mjc2OQ%3D%3D.2"],
             siteName: "Instagram",
             description: "See this Instagram photo by @silvandaehn • 25 likes"
@@ -176,6 +184,7 @@ class OpenGraphMockDataProvider: NSObject {
             title: "Auto",
             type: "video",
             url: "https://vimeo.com/170888135",
+            resolvedURL: "https://vimeo.com/170888135",
             imageUrls: ["https://i.vimeocdn.com/video/576126576_1280x720.jpg"],
             siteName: "Vimeo",
             description: "Cars dance on highways, crowds of people wash across sidewalk shores.   RISD Senior film - 2016"
@@ -193,6 +202,7 @@ class OpenGraphMockDataProvider: NSObject {
             title: "Brazil’s Olympic Catastrophe",
             type: "article",
             url: "http://www.nytimes.com/2016/07/03/opinion/sunday/brazils-olympic-catastrophe.html",
+            resolvedURL: "http://www.nytimes.com/2016/07/03/opinion/sunday/brazils-olympic-catastrophe.html",
             imageUrls: ["https://static01.nyt.com/images/2016/07/03/opinion/sunday/03barbara/03barbara-facebookJumbo.jpg"],
             description: "Can Rio pull off the Games with only weeks to go?"
         )
@@ -209,6 +219,7 @@ class OpenGraphMockDataProvider: NSObject {
             title: "Holocaust Museum to visitors: Please stop catching Pokémon here",
             type: "article",
             url: "https://www.washingtonpost.com/news/the-switch/wp/2016/07/12/holocaust-museum-to-visitors-please-stop-catching-pokemon-here/",
+            resolvedURL: "https://www.washingtonpost.com/news/the-switch/wp/2016/07/12/holocaust-museum-to-visitors-please-stop-catching-pokemon-here/",
             imageUrls: ["https://images.washingtonpost.com/?url=http://img.washingtonpost.com/blogs/the-switch/files/2016/07/DoduoHM.png&w=1484&op=resize&opt=1&filter=antialias"],
             siteName: "Washington Post",
             description: "Melding the real world with a digital one can sometimes lead to uncomfortable consequences."
@@ -226,6 +237,7 @@ class OpenGraphMockDataProvider: NSObject {
             title: "The tune for this summer — audio filters — Wire News",
             type: "article",
             url: "https://medium.com/wire-news/the-tune-for-this-summer-audio-filters-eca8cb0b4c57",
+            resolvedURL: "https://medium.com/wire-news/the-tune-for-this-summer-audio-filters-eca8cb0b4c57",
             imageUrls: ["https://cdn-images-1.medium.com/max/1200/1*-txfQwEIvfMETmDi_hdfpQ.png"],
             siteName: "Medium",
             description: "Hello again from the Wire news room. Even though it’s a hot summer out there, we have been busy making our app the most modern, private…"
@@ -243,6 +255,7 @@ class OpenGraphMockDataProvider: NSObject {
             title: "Wire — modern, private communication. For iOS, Android, OS X, Windows and web.",
             type: "website",
             url: "https://wire.com/",
+            resolvedURL: "https://wire.com/",
             imageUrls: ["https://lh3.ggpht.com/gbxDT30ZwpwYMCF7ilrSaIpRQP3Z1Xdx2WUcyW5x_e8FDN8kA4CJGQQ0fFpVhKiGnPkAIOEf7S1_9cNi684Be-OY=s1024"],
             description: "HD quality calls, private and group chats with inline photos, music and video. Secure and perfectly synced across your devices."
         )
@@ -259,6 +272,7 @@ class OpenGraphMockDataProvider: NSObject {
             title: "Which Pokémon Go team should you join?",
             type: "website",
             url: "http://www.polygon.com/2016/7/11/12148448/which-pokemon-go-team-should-i-pick",
+            resolvedURL: "http://www.polygon.com/2016/7/11/12148448/which-pokemon-go-team-should-i-pick",
             imageUrls: ["https://cdn1.vox-cdn.com/thumbor/VhM0gxcxqzqlpHJNQmqPuilpdXA=/0x1075:1440x1885/1600x900/cdn0.vox-cdn.com/uploads/chorus_image/image/50077599/Screenshot_20160709-102153.0.0.png"],
             siteName: "Polygon",
             description: "How to answer one of the game's toughest questions"
@@ -276,6 +290,7 @@ class OpenGraphMockDataProvider: NSObject {
             title: "„Wolves of Winter“ aus „Ellipsis (Deluxe)“ von Biffy Clyro auf Apple Music",
             type: "website",
             url: "https://itunes.apple.com/de/album/ellipsis-deluxe/id1093554521",
+            resolvedURL: "https://itunes.apple.com/de/album/ellipsis-deluxe/id1093554521",
             imageUrls: ["http://is2.mzstatic.com/image/thumb/Music49/v4/7b/29/cd/7b29cd44-0d47-963e-5ffe-89d67c6e7dc4/source/1200x630bf.jpg"],
             siteName: "iTunes",
             description: "Hör dir „Wolves of Winter“ vom Album „Ellipsis (Deluxe)“ an. Kaufe den Titel für 1,29 €. Kostenlos mit Apple Music-Abo."
@@ -293,6 +308,7 @@ class OpenGraphMockDataProvider: NSObject {
             title: "„Ellipsis (Deluxe)“ von Biffy Clyro auf Apple Music",
             type: "website",
             url: "https://itunes.apple.com/de/album/ellipsis-deluxe/id1093554521",
+            resolvedURL: "https://itunes.apple.com/de/album/ellipsis-deluxe/id1093554521",
             imageUrls: ["http://is2.mzstatic.com/image/thumb/Music49/v4/7b/29/cd/7b29cd44-0d47-963e-5ffe-89d67c6e7dc4/source/1200x630bf.jpg"],
             siteName: "iTunes",
             description: "Hör dir „Wolves of Winter“ vom Album „Ellipsis (Deluxe)“ an. Kaufe den Titel für 1,29 €. Kostenlos mit Apple Music-Abo."
@@ -310,6 +326,7 @@ class OpenGraphMockDataProvider: NSObject {
             title: "Mario Gomez: Besiktas verlängert Leihe",
             type: "article",
             url: "https://de.sports.yahoo.com/news/mario-gomez-besiktas-verl%c3%a4ngert-leihe-115423346.html",
+            resolvedURL: "https://de.sports.yahoo.com/news/mario-gomez-besiktas-verl%c3%a4ngert-leihe-115423346.html",
             imageUrls: ["https://s.yimg.com/bt/api/res/1.2/Hm3djeE3ivlN_WaKu7eOog--/YXBwaWQ9eW5ld3NfbGVnbztxPTc1O3c9NjAw/http://media.zenfs.com/de-DE/homerun/de.goal.com/629c73161149247ba39c58e4d8a951a4.cf.png"],
             siteName: "Yahoo Sport",
             description: "Der deutsche Stürmer spielt offenbar auch in der kommenden Saison in Istanbul. Die Türken leihen ihn demnach erneut aus. Ein wichtiges Argument sei die Champions League."


### PR DESCRIPTION
## What's new in this PR?

### Issues

Two main issues:
1. some shared links were not recognised as links, so it wasn't possible to open them via `openURL`.
2. images from Open Graph weren't displayed.

### Causes

1. in some cases, `permanentURL` was not resolved correctly - e.g. `http://` was not added to this link: designtoolsberlin.com/hackerguide . I (and @mikeger) added the `resolvedURL` parameter, so `ZMLinkPreview` can fallback to the correct resolved url (with `http://` and/or `www`). 
2. the image was downloaded correctly, but the container cell wasn't updated

### Solutions

Solutions implemented with this PR:
- added the `resolvedURL` field in `LinkPreviewTypes.swift` and `resolvedURLString` in the signatures of calling methods.
- fixed tests
- fixed `permament` typo

## Dependencies

Needs releases with:

- [ ] https://github.com/wireapp/wire-ios-data-model/pull/397
- [ ] https://github.com/wireapp/wire-ios/pull/1456