### PR TITLE
Fix/ignore svg image

### DIFF
--- a/WireLinkPreview/ImageDownloader.swift
+++ b/WireLinkPreview/ImageDownloader.swift
@@ -78,7 +78,10 @@ extension HTTPURLResponse {
     var contentTypeImage: Bool {
         let contentTypeKey = HeaderKey.contentType.rawValue
         guard let contentType = allHeaderFields[contentTypeKey] as? String ?? allHeaderFields[contentTypeKey.lowercased()] as? String else { return false }
-        return contentType.contains("image")
+        
+        // we don't consider svg a valid image type b/c UIImage doesn't directly
+        // support it
+        return contentType.contains("image") && !contentType.contains("svg")
     }
 
 }

--- a/WireLinkPreviewTests/ImageDownloaderTests.swift
+++ b/WireLinkPreviewTests/ImageDownloaderTests.swift
@@ -113,6 +113,10 @@ class ImageDownloaderTests: XCTestCase {
         assertThatItReturnsTheImageData(true, withHeaderFields: ["content-type": "image/gif"])
     }
     
+    func testThatItDoesNotReturnTheDataIfTheResponseHeaderContainsContentTypeImage_SVG() {
+        assertThatItReturnsTheImageData(false, withHeaderFields: ["content-type": "image/svg"])
+    }
+    
     func testThatItDoesNotReturnTheDataInTheCompletionIfTheResponseHeaderDoesNotContainContentTypeImage() {
         assertThatItReturnsTheImageData(false, withHeaderFields: ["Content-Type": "text/html"])
     }


### PR DESCRIPTION
# What's in this PR?

## Issue
Broken link preview's are being generated when then thumbnail image is a SVG.

## Cause
Although we are successfully downloading the SVG image, `UIImage` doesn't directly support this format and therefore can't render the image.

## Solution
Ignore the SVG image type.