### PR TITLE
ask delegate if link should be detected

### DIFF
--- a/WireLinkPreview/LinkPreviewDetector.swift
+++ b/WireLinkPreview/LinkPreviewDetector.swift
@@ -24,7 +24,7 @@ import Foundation
 }
 
 public protocol LinkPreviewDetectorDelegate: class {
-    func shouldDetectURL(_ url: URL, inRange range: NSRange, inText text: String) -> Bool
+    func shouldDetectURL(_ url: URL, range: NSRange, text: String) -> Bool
 }
 
 public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
@@ -68,7 +68,7 @@ public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
         guard let matches = linkDetector?.matches(in: text, options: [], range: range) else { return [] }
         return matches.flatMap {
             guard let url = $0.url,
-                delegate?.shouldDetectURL(url, inRange: $0.range, inText: text) ?? true
+                delegate?.shouldDetectURL(url, range: $0.range, text: text) ?? true
                 else { return nil }
             return (url, $0.range)
         }

--- a/WireLinkPreview/LinkPreviewDetector.swift
+++ b/WireLinkPreview/LinkPreviewDetector.swift
@@ -23,7 +23,13 @@ import Foundation
     @objc optional func downloadLinkPreviews(inText text: String, completion: @escaping ([LinkPreview]) -> Void)
 }
 
+public protocol LinkPreviewDetectorDelegate: class {
+    func shouldDetectURL(_ url: URL, inRange range: NSRange, inText text: String) -> Bool
+}
+
 public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
+    
+    public weak var delegate: LinkPreviewDetectorDelegate?
     
     private let blacklist = PreviewBlacklist()
     private let linkDetector : NSDataDetector? = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue)
@@ -61,7 +67,9 @@ public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
         let range = NSRange(location: 0, length: text.characters.count)
         guard let matches = linkDetector?.matches(in: text, options: [], range: range) else { return [] }
         return matches.flatMap {
-            guard let url = $0.url else { return nil }
+            guard let url = $0.url,
+                delegate?.shouldDetectURL(url, inRange: $0.range, inText: text) ?? true
+                else { return nil }
             return (url, $0.range)
         }
     }

--- a/WireLinkPreviewTests/IntegrationTests.swift
+++ b/WireLinkPreviewTests/IntegrationTests.swift
@@ -52,7 +52,7 @@ class IntegrationTests: XCTestCase {
     }
     
     func testThatItParsesSampleDataYouTube() {
-        let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "video", siteNameString: "YouTube", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
+        let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "video.other", siteNameString: "YouTube", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.youtubeData()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }

--- a/WireLinkPreviewTests/LinkPreviewDetectorTests.swift
+++ b/WireLinkPreviewTests/LinkPreviewDetectorTests.swift
@@ -58,20 +58,6 @@ class LinkPreviewDetectorTests: XCTestCase {
     
     func testThatItReturnsTheURLsAndOffsetsOfMultipleLinksInAText() {
         // given
-        let text = "This is a sample containig a link: www.example.com"
-        
-        // when
-        let links = sut.containedLinks(inText: text)
-        
-        // then
-        XCTAssertEqual(links.count, 1)
-        let linkWithOffset = links.first
-        XCTAssertEqual(linkWithOffset?.URL, URL(string: "http://www.example.com")!)
-        XCTAssertEqual(linkWithOffset?.range.location, 35)
-    }
-    
-    func testThatItDoesNotReturnALinkIfThereIsNoneInAText() {
-        // given
         let text = "First: www.example.com/first and second: www.example.com/second"
         
         // when
@@ -86,9 +72,20 @@ class LinkPreviewDetectorTests: XCTestCase {
         XCTAssertEqual(second?.range.location, 41)
     }
     
+    func testThatItDoesNotReturnALinkIfThereIsNoneInAText() {
+        // given
+        let text = "This is a sample containing no link"
+        
+        // when
+        let links = sut.containedLinks(inText: text)
+        
+        // then
+        XCTAssertTrue(links.isEmpty)
+    }
+    
     func testThatItCallsTheCompletionWithAnEmptyArrayWhenThereIsNoLinkInTheText() {
         // given
-        let text = "This is a sample containig no link"
+        let text = "This is a sample containing no link"
         let completionExpectation = expectation(description: "It calls the completion closure")
 
         // when

--- a/WireLinkPreviewTests/LinkPreviewDetectorTests.swift
+++ b/WireLinkPreviewTests/LinkPreviewDetectorTests.swift
@@ -22,12 +22,13 @@ import XCTest
 
 
 
-class LinkPreviewDetectorTests: XCTestCase {
+class LinkPreviewDetectorTests: XCTestCase, LinkPreviewDetectorDelegate {
     
     var sut: LinkPreviewDetector!
     var mockImageTask: MockURLSessionDataTask!
     var imageDownloader: MockImageDownloader!
     var previewDownloader: MockPreviewDownloader!
+    var shouldDetectLink = true
     
     override func setUp() {
         super.setUp()
@@ -40,6 +41,10 @@ class LinkPreviewDetectorTests: XCTestCase {
             resultsQueue: .main,
             workerQueue: .main
         )
+    }
+    
+    func shouldDetectURL(_ url: URL, range: NSRange, text: String) -> Bool {
+        return shouldDetectLink
     }
     
     func testThatItReturnsTheDetectedLinkAndOffsetInAText() {
@@ -81,6 +86,22 @@ class LinkPreviewDetectorTests: XCTestCase {
         
         // then
         XCTAssertTrue(links.isEmpty)
+    }
+    
+    func testThatItObeysItsDelegate() {
+        sut.delegate = self
+        [true, false].forEach {
+            // given
+            self.shouldDetectLink = $0
+            let text = "This is a sample containing a link: www.example.com"
+            
+            // when
+            let links = sut.containedLinks(inText: text)
+            
+            // then
+            XCTAssertEqual(links.count, self.shouldDetectLink ? 1 : 0)
+        }
+        
     }
     
     func testThatItCallsTheCompletionWithAnEmptyArrayWhenThereIsNoLinkInTheText() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

We want to be able to decide whether a preview should be generated for a link. 

### Solutions

Simply add a delegate to `LinkPreviewDetector` and ask whether a link should be detected.
