### PR TITLE
Fix/link preview detector delegate

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,14 @@ You can now open the Xcode project and build.
 
 ### Usage:
 
-Consumers of this framework should mostly interact with the `LinkPreviewDetector` type, it can be used to check if a given text contains a link using the `containsLink:inText` method and if it does it can be used to download the previews asynchronously using `downloadLinkPreviews:inText:delegate:completion`.
+Consumers of this framework should mostly interact with the `LinkPreviewDetector` type, it can be used to check if a given text contains a link using the `containsLink:inText` method and if it does it can be used to download the previews asynchronously using `downloadLinkPreviews:inText:completion`.
 
 ```swift
 let text = "Text containing a link to your awesome tweet"
 let detector = LinkPreviewDetector(resultsQueue: .main)
 
 guard detector.containsLink(inText: text) else { return }
-detector.downloadLinkPreviews(inText: text, delegate: nil) { previews in
+detector.downloadLinkPreviews(inText: text) { previews in
     // Do something with the previews
 }
 ```

--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ You can now open the Xcode project and build.
 
 ### Usage:
 
-Consumers of this framework should mostly interact with the `LinkPreviewDetector` type, it can be used to check if a given text contains a link using the `containsLink:inText` method and if it does it can be used to download the previews asynchronously using `downloadLinkPreviews:inText:completion`.
+Consumers of this framework should mostly interact with the `LinkPreviewDetector` type, it can be used to check if a given text contains a link using the `containsLink:inText` method and if it does it can be used to download the previews asynchronously using `downloadLinkPreviews:inText:delegate:completion`.
 
 ```swift
 let text = "Text containing a link to your awesome tweet"
 let detector = LinkPreviewDetector(resultsQueue: .main)
 
 guard detector.containsLink(inText: text) else { return }
-detector.downloadLinkPreviews(inText: text) { previews in
+detector.downloadLinkPreviews(inText: text, delegate: nil) { previews in
     // Do something with the previews
 }
 ```
 
-A call to this method will also download the images specified in the Open Graph data. The completion returns an array of `LinkPreview` objects which currently are either of type `Article` or `TwitterStatus`, while the count of elements in the array is also limited to one at for now.
+A call to this method will also download the images specified in the Open Graph data. The completion returns an array of `LinkPreview` objects which currently are either of type `Article` or `TwitterStatus`, while the count of elements in the array is also limited to one at for now. Note, use the delegate `LinkPreviewDetectorDelegate` to control which which detected links will have their preview generated.

--- a/WireLinkPreview/LinkPreviewDetector.swift
+++ b/WireLinkPreview/LinkPreviewDetector.swift
@@ -20,10 +20,10 @@
 import Foundation
 
 @objc public protocol LinkPreviewDetectorType {
-    @objc optional func downloadLinkPreviews(inText text: String, delegate: LinkPreviewDetectorDelegate?, completion: @escaping ([LinkPreview]) -> Void)
+    @objc optional func downloadLinkPreviews(inText text: String, completion: @escaping ([LinkPreview]) -> Void)
 }
 
-@objc public protocol LinkPreviewDetectorDelegate: class {
+public protocol LinkPreviewDetectorDelegate: class {
     func shouldDetectURL(_ url: URL, range: NSRange, text: String) -> Bool
 }
 
@@ -85,8 +85,7 @@ public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
      - parameter text:       The text with potentially contained links, if links are found the preview data is downloaded.
      - parameter completion: The completion closure called when the link previews (and it's images) have been downloaded.
      */
-    public func downloadLinkPreviews(inText text: String, delegate: LinkPreviewDetectorDelegate? = nil, completion : @escaping DetectCompletion) {
-        self.delegate = delegate
+    public func downloadLinkPreviews(inText text: String, completion : @escaping DetectCompletion) {
         guard let (url, range) = containedLinks(inText: text).first, !blacklist.isBlacklisted(url) else { return callCompletion(completion, result: []) }
         previewDownloader.requestOpenGraphData(fromURL: url) { [weak self] openGraphData in
             guard let `self` = self else { return }

--- a/WireLinkPreview/LinkPreviewDetector.swift
+++ b/WireLinkPreview/LinkPreviewDetector.swift
@@ -20,10 +20,10 @@
 import Foundation
 
 @objc public protocol LinkPreviewDetectorType {
-    @objc optional func downloadLinkPreviews(inText text: String, completion: @escaping ([LinkPreview]) -> Void)
+    @objc optional func downloadLinkPreviews(inText text: String, delegate: LinkPreviewDetectorDelegate?, completion: @escaping ([LinkPreview]) -> Void)
 }
 
-public protocol LinkPreviewDetectorDelegate: class {
+@objc public protocol LinkPreviewDetectorDelegate: class {
     func shouldDetectURL(_ url: URL, range: NSRange, text: String) -> Bool
 }
 
@@ -85,7 +85,8 @@ public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
      - parameter text:       The text with potentially contained links, if links are found the preview data is downloaded.
      - parameter completion: The completion closure called when the link previews (and it's images) have been downloaded.
      */
-    public func downloadLinkPreviews(inText text: String, completion : @escaping DetectCompletion) {
+    public func downloadLinkPreviews(inText text: String, delegate: LinkPreviewDetectorDelegate? = nil, completion : @escaping DetectCompletion) {
+        self.delegate = delegate
         guard let (url, range) = containedLinks(inText: text).first, !blacklist.isBlacklisted(url) else { return callCompletion(completion, result: []) }
         previewDownloader.requestOpenGraphData(fromURL: url) { [weak self] openGraphData in
             guard let `self` = self else { return }

--- a/WireLinkPreview/LinkPreviewDetector.swift
+++ b/WireLinkPreview/LinkPreviewDetector.swift
@@ -21,9 +21,10 @@ import Foundation
 
 @objc public protocol LinkPreviewDetectorType {
     @objc optional func downloadLinkPreviews(inText text: String, completion: @escaping ([LinkPreview]) -> Void)
+    weak var delegate: LinkPreviewDetectorDelegate? { get set }
 }
 
-public protocol LinkPreviewDetectorDelegate: class {
+@objc public protocol LinkPreviewDetectorDelegate: class {
     func shouldDetectURL(_ url: URL, range: NSRange, text: String) -> Bool
 }
 


### PR DESCRIPTION
## What's new in this PR?

A minor follow up to [this PR](https://github.com/wireapp/wire-ios-link-preview/pull/24): 

Allow passing of an instance of `LinkPreviewDetectorDelegate` in the `LinkPreviewDetectorType` method `downloadLinkPreviews(inText:completion)`. This allows us to set the delegate without casting an instance of the protocol type to a specific implementation type. 