### PR TITLE
Pin website version in tests to make sure they don't break

### DIFF
--- a/WireLinkPreviewTests/IntegrationTests.swift
+++ b/WireLinkPreviewTests/IntegrationTests.swift
@@ -77,7 +77,7 @@ class IntegrationTests: XCTestCase {
     
     func testThatItParsesSampleDataFoursquare() {
         let expectation = OpenGraphDataExpectation(numberOfImages: 4, type: "playfoursquare:venue", siteNameString: "Foursquare", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: true)
-        let mockData = OpenGraphMockDataProvider.foursqaureData()
+        let mockData = OpenGraphMockDataProvider.foursquareData()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
     
@@ -133,14 +133,23 @@ class IntegrationTests: XCTestCase {
         let sut = PreviewDownloader(resultsQueue: .main, parsingQueue: .main)
 
         // when
+
+        var resolvedURL: URL
+
+        if let version = mockData.urlVersion {
+            resolvedURL = URL(string: "http://web.archive.org/web/\(version)/\(mockData.urlString)")!
+        } else {
+            resolvedURL = URL(string: mockData.urlString)!
+        }
+
         var result: OpenGraphData?
-        sut.requestOpenGraphData(fromURL: URL(string: mockData.urlString)!) { data in
+        sut.requestOpenGraphData(fromURL: resolvedURL) { data in
             result = data
             XCTAssertNotNil(data, line: line)
             completionExpectation.fulfill()
         }
 
-        waitForExpectations(timeout: 10, handler: nil)
+        waitForExpectations(timeout: 60, handler: nil)
         guard let data = result else {
             return XCTFail("Could not extract open graph data from \(mockData.urlString)", line: line)
         }

--- a/WireLinkPreviewTests/OpenGraphDataTests.swift
+++ b/WireLinkPreviewTests/OpenGraphDataTests.swift
@@ -92,7 +92,7 @@ class OpenGraphDataTests: XCTestCase {
     }
     
     func testThatItCreatesTheCorrectLinkPreview_Foursqaure() {
-        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.foursqaureData(), expectedClass: Article.self)
+        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.foursquareData(), expectedClass: Article.self)
     }
     
     func testThatItCreatesTheCorrectLinkPreview_Nytimes() {
@@ -141,7 +141,7 @@ class OpenGraphDataTests: XCTestCase {
     
     func testThatItUsesTheGivenOriginalURLAndCharacterOffsetWhenCreatingALinkPreview() {
         // given
-        let data = OpenGraphMockDataProvider.foursqaureData().expected
+        let data = OpenGraphMockDataProvider.foursquareData().expected
         let originalURLString = "www.example.com"
         
         // when

--- a/WireLinkPreviewTests/OpenGraphMockDataProvider.swift
+++ b/WireLinkPreviewTests/OpenGraphMockDataProvider.swift
@@ -24,11 +24,11 @@ struct OpenGraphMockData {
     let head: String
     let expected: OpenGraphData?
     let urlString: String
+    let urlVersion: String?
 }
 
 class OpenGraphMockDataProvider: NSObject {
 
-    
     static func twitterData() -> OpenGraphMockData {
         
         let expected = OpenGraphData(
@@ -44,7 +44,8 @@ class OpenGraphMockDataProvider: NSObject {
         return OpenGraphMockData(
             head: fixtureWithName("twitter_head"),
             expected: expected,
-            urlString: expected.url
+            urlString: expected.url,
+            urlVersion: nil
         )
     }
     
@@ -64,11 +65,12 @@ class OpenGraphMockDataProvider: NSObject {
         return OpenGraphMockData(
             head: fixtureWithName("twitter_images_head"),
             expected: expected,
-            urlString: expected.url
+            urlString: expected.url,
+            urlVersion: nil
         )
     }
     
-    static func foursqaureData() -> OpenGraphMockData {
+    static func foursquareData() -> OpenGraphMockData {
         
         var expected = OpenGraphData(
             title: "NETA Mexican Street Food",
@@ -85,7 +87,8 @@ class OpenGraphMockDataProvider: NSObject {
         return OpenGraphMockData(
             head: fixtureWithName("foursquare_head"),
             expected: expected,
-            urlString: expected.url
+            urlString: expected.url,
+            urlVersion: nil
         )
     }
 
@@ -103,7 +106,8 @@ class OpenGraphMockDataProvider: NSObject {
         return OpenGraphMockData(
             head: fixtureWithName("verge_head"),
             expected: expected,
-            urlString: expected.url
+            urlString: expected.url,
+            urlVersion: "20171116072016"
         )
     }
 
@@ -121,7 +125,8 @@ class OpenGraphMockDataProvider: NSObject {
         return OpenGraphMockData(
             head: fixtureWithName("youtube_head"),
             expected: expected,
-            urlString: expected.url
+            urlString: expected.url,
+            urlVersion: nil
         )
     }
 
@@ -139,7 +144,8 @@ class OpenGraphMockDataProvider: NSObject {
         return OpenGraphMockData(
             head: fixtureWithName("guardian_head"),
             expected: expected,
-            urlString: expected.url
+            urlString: expected.url,
+            urlVersion: "20170918063647"
         )
     }
 
@@ -157,7 +163,8 @@ class OpenGraphMockDataProvider: NSObject {
         return OpenGraphMockData(
             head: fixtureWithName("crash"),
             expected: expected,
-            urlString: expected.url
+            urlString: expected.url,
+            urlVersion: nil
         )
     }
     
@@ -175,7 +182,8 @@ class OpenGraphMockDataProvider: NSObject {
         return OpenGraphMockData(
             head: fixtureWithName("crash_emoji"),
             expected: expected,
-            urlString: expected.url
+            urlString: expected.url,
+            urlVersion: nil
         )
     }
     
@@ -193,7 +201,8 @@ class OpenGraphMockDataProvider: NSObject {
         return OpenGraphMockData(
             head: fixtureWithName("instagram_head"),
             expected: expected,
-            urlString: expected.url
+            urlString: expected.url,
+            urlVersion: nil
         )
     }
 
@@ -211,7 +220,8 @@ class OpenGraphMockDataProvider: NSObject {
         return OpenGraphMockData(
             head: fixtureWithName("vimeo_head"),
             expected: expected,
-            urlString: expected.url
+            urlString: expected.url,
+            urlVersion: nil
         )
     }
 
@@ -228,7 +238,8 @@ class OpenGraphMockDataProvider: NSObject {
         return OpenGraphMockData(
             head: fixtureWithName("nytimes_head"),
             expected: expected,
-            urlString: expected.url
+            urlString: expected.url,
+            urlVersion: "20180523034751"
         )
     }
     
@@ -246,7 +257,8 @@ class OpenGraphMockDataProvider: NSObject {
         return OpenGraphMockData(
             head: fixtureWithName("washington_post_head"),
             expected: expected,
-            urlString: expected.url
+            urlString: expected.url,
+            urlVersion: "20180519102639"
         )
     }
     
@@ -264,7 +276,8 @@ class OpenGraphMockDataProvider: NSObject {
         return OpenGraphMockData(
             head: fixtureWithName("medium_head"),
             expected: expected,
-            urlString: expected.url
+            urlString: expected.url,
+            urlVersion: nil
         )
     }
     
@@ -281,7 +294,8 @@ class OpenGraphMockDataProvider: NSObject {
         return OpenGraphMockData(
             head: fixtureWithName("wire_head"),
             expected: expected,
-            urlString: expected.url
+            urlString: expected.url,
+            urlVersion: nil
         )
     }
 
@@ -299,7 +313,8 @@ class OpenGraphMockDataProvider: NSObject {
         return OpenGraphMockData(
             head: fixtureWithName("polygon_head"),
             expected: expected,
-            urlString: expected.url
+            urlString: expected.url,
+            urlVersion: "20171126020245"
         )
     }
 
@@ -317,7 +332,8 @@ class OpenGraphMockDataProvider: NSObject {
         return OpenGraphMockData(
             head: fixtureWithName("itunes_head"),
             expected: expected,
-            urlString: expected.url
+            urlString: expected.url,
+            urlVersion: nil
         )
     }
 
@@ -335,7 +351,8 @@ class OpenGraphMockDataProvider: NSObject {
         return OpenGraphMockData(
             head: fixtureWithName("itunes_without_title_head"),
             expected: expected,
-            urlString: expected.url
+            urlString: expected.url,
+            urlVersion: nil
         )
     }
     
@@ -353,7 +370,8 @@ class OpenGraphMockDataProvider: NSObject {
         return OpenGraphMockData(
             head: fixtureWithName("yahoo_sports_head"),
             expected: expected,
-            urlString: expected.url
+            urlString: expected.url,
+            urlVersion: nil
         )
     }
 

--- a/WireLinkPreviewTests/OpenGraphScannerTests.swift
+++ b/WireLinkPreviewTests/OpenGraphScannerTests.swift
@@ -35,7 +35,7 @@ class OpenGraphScannerTests: XCTestCase {
     }
     
     func testThatItCanParseCorrectlyStrippedSampleData_Foursquare() {
-        assertThatItParsesSampleDataCorrectly(OpenGraphMockDataProvider.foursqaureData())
+        assertThatItParsesSampleDataCorrectly(OpenGraphMockDataProvider.foursquareData())
     }
 
     func testThatItCanParseCorrectlyStrippedSampleData_YouTube() {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Tests were frequently breaking because the websites used to test the parser changed their layout/tags, which led to inconsistencies with the test data.

### Solutions

We pin the version of the mock data to the date it was generated. We use the [Internet Archive](https://web.archive.org) to get the version available at the time we created the test.

To get the url version, copy the date from the Web Archive url.