### PR TITLE
Fix/detect link range

### DIFF
--- a/WireLinkPreview/LinkPreviewDetector.swift
+++ b/WireLinkPreview/LinkPreviewDetector.swift
@@ -65,7 +65,7 @@ public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
     }
     
     func containedLinks(inText text: String) -> [URLWithRange] {
-        let range = NSRange(location: 0, length: text.count)
+        let range = NSRange(location: 0, length: (text as NSString).length)
         guard let matches = linkDetector?.matches(in: text, options: [], range: range) else { return [] }
         return matches.compactMap {
             guard let url = $0.url,

--- a/WireLinkPreviewTests/LinkPreviewDetectorTests.swift
+++ b/WireLinkPreviewTests/LinkPreviewDetectorTests.swift
@@ -61,6 +61,20 @@ class LinkPreviewDetectorTests: XCTestCase, LinkPreviewDetectorDelegate {
         XCTAssertEqual(linkWithOffset?.range.location, 35)
     }
     
+    func testThatItReturnsTheDetectedLinkAndOffsetInATextContainingWideEmojis() {
+        // given
+        let text = "This is a sample 👩🏻‍🚀👨‍👩‍👧‍👧😣 containig a link: www.example.com"
+        
+        // when
+        let links = sut.containedLinks(inText: text)
+        
+        // then
+        XCTAssertEqual(links.count, 1)
+        let linkWithOffset = links.first
+        XCTAssertEqual(linkWithOffset?.URL, URL(string: "http://www.example.com")!)
+        XCTAssertEqual(linkWithOffset?.range.location, 35 + ("👩🏻‍🚀👨‍👩‍👧‍👧😣 " as NSString).length)
+    }
+    
     func testThatItReturnsTheURLsAndOffsetsOfMultipleLinksInAText() {
         // given
         let text = "First: www.example.com/first and second: www.example.com/second"


### PR DESCRIPTION
## What's new in this PR?

### Issues
If a message contains multi-codepoint emojis and the URL is at the end of the message, then the link preview is incorrectly detected, if at all.

### Causes

Links are detected within an `NSRange` of the message, which is supposed to span the whole text. This whole range was being constructed using the `count` property of a swift `String`, rather than an `NSString`. Since `count` treats all emojis as a single character, the "whole" range would possibly not reach the end of the string.

### Solutions
Cast the text to an `NSString` to get the length of the string.

