### PR TITLE
Performance fixes

### DIFF
--- a/WireLinkPreview/LinkPreviewDetector.swift
+++ b/WireLinkPreview/LinkPreviewDetector.swift
@@ -98,6 +98,9 @@ public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
             }
         }
     }
+
+    deinit {
+        previewDownloader.tearDown()
     }
     
 }

--- a/WireLinkPreview/LinkPreviewDetector.swift
+++ b/WireLinkPreview/LinkPreviewDetector.swift
@@ -37,23 +37,20 @@ public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
     private let previewDownloader: PreviewDownloaderType
     private let imageDownloader: ImageDownloaderType
     private let workerQueue: OperationQueue
-    private let resultsQueue: OperationQueue
     
     public typealias DetectCompletion = ([LinkPreview]) -> Void
     typealias URLWithRange = (URL: URL, range: NSRange)
     
-    public convenience init(resultsQueue: OperationQueue) {
+    public convenience override init() {
         let workerQueue = OperationQueue()
         self.init(
             previewDownloader: PreviewDownloader(resultsQueue: workerQueue),
             imageDownloader: ImageDownloader(resultsQueue: workerQueue),
-            resultsQueue: resultsQueue,
             workerQueue: workerQueue
         )
     }
     
-    init(previewDownloader: PreviewDownloaderType, imageDownloader: ImageDownloaderType, resultsQueue: OperationQueue, workerQueue: OperationQueue) {
-        self.resultsQueue = resultsQueue
+    init(previewDownloader: PreviewDownloaderType, imageDownloader: ImageDownloaderType, workerQueue: OperationQueue) {
         self.workerQueue = workerQueue
         self.previewDownloader = previewDownloader
         self.imageDownloader = imageDownloader
@@ -80,6 +77,8 @@ public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
      The preview data is generated from the [Open Graph](http://ogp.me) information contained in the head of the html of the link.
      For debugging Open Graph please use the [Sharing Debugger](https://developers.facebook.com/tools/debug/sharing).
 
+     The completion block will be called on private background queue, make sure to switch to main or other queue.
+
      **Attention: For now this method only downloads the preview data (and only one image for this link preview) 
      for the first link found in the text!**
 
@@ -87,23 +86,18 @@ public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
      - parameter completion: The completion closure called when the link previews (and it's images) have been downloaded.
      */
     public func downloadLinkPreviews(inText text: String, completion : @escaping DetectCompletion) {
-        guard let (url, range) = containedLinks(inText: text).first, !blacklist.isBlacklisted(url) else { return callCompletion(completion, result: []) }
+        guard let (url, range) = containedLinks(inText: text).first, !blacklist.isBlacklisted(url) else { return completion([]) }
         previewDownloader.requestOpenGraphData(fromURL: url) { [weak self] openGraphData in
             guard let `self` = self else { return }
             let originalURLString = (text as NSString).substring(with: range)
-            guard let data = openGraphData else { return self.callCompletion(completion, result: []) }
+            guard let data = openGraphData else { return completion([]) }
 
             let linkPreview = data.linkPreview(originalURLString, offset: range.location)
             linkPreview.requestAssets(withImageDownloader: self.imageDownloader) { _ in
-                self.callCompletion(completion, result: [linkPreview])
+                completion([linkPreview])
             }
         }
     }
-    
-    private func callCompletion(_ completion: @escaping DetectCompletion, result: [LinkPreview]) {
-        resultsQueue.addOperation { 
-            completion(result)
-        }
     }
     
 }

--- a/WireLinkPreview/PreviewDownloader.swift
+++ b/WireLinkPreview/PreviewDownloader.swift
@@ -23,6 +23,7 @@ private let userAgent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHT
 
 protocol PreviewDownloaderType {
     func requestOpenGraphData(fromURL url: URL, completion: @escaping (OpenGraphData?) -> Void)
+    func tearDown()
 }
 
 enum HeaderKey: String {
@@ -132,6 +133,10 @@ final class PreviewDownloader: NSObject, URLSessionDataDelegate, PreviewDownload
         }
         
         scanner.parse()
+    }
+
+    func tearDown() {
+        session.invalidateAndCancel()
     }
 
 }

--- a/WireLinkPreview/URLSessionProtocols.swift
+++ b/WireLinkPreview/URLSessionProtocols.swift
@@ -24,6 +24,7 @@ typealias DataTaskCompletion = (Data?, URLResponse?, Error?) -> Void
 protocol URLSessionType {
     func dataTask(with request: URLRequest) -> URLSessionDataTaskType
     func dataTaskWithURL(_ url: URL, completionHandler: @escaping DataTaskCompletion) -> URLSessionDataTaskType
+    func invalidateAndCancel()
 }
 
 protocol URLSessionDataTaskType {

--- a/WireLinkPreviewTests/DownloaderMocks.swift
+++ b/WireLinkPreviewTests/DownloaderMocks.swift
@@ -34,6 +34,11 @@ class MockPreviewDownloader: PreviewDownloaderType {
         requestOpenGraphDataCompletions.append(completion)
         completion(mockOpenGraphData)
     }
+
+    var tornDown = false
+    func tearDown() {
+        tornDown = true
+    }
 }
 
 class MockImageDownloader: ImageDownloaderType {

--- a/WireLinkPreviewTests/LinkPreviewDetectorTests.swift
+++ b/WireLinkPreviewTests/LinkPreviewDetectorTests.swift
@@ -41,9 +41,28 @@ class LinkPreviewDetectorTests: XCTestCase, LinkPreviewDetectorDelegate {
             workerQueue: .main
         )
     }
+
+    override func tearDown() {
+        mockImageTask = nil
+        previewDownloader = nil
+        imageDownloader = nil
+        sut = nil
+        super.tearDown()
+    }
     
     func shouldDetectURL(_ url: URL, range: NSRange, text: String) -> Bool {
         return shouldDetectLink
+    }
+
+    func testThatItCallsTeardownAfterDeallocating() {
+        // given
+        XCTAssertFalse(previewDownloader.tornDown)
+
+        // when
+        sut = nil
+
+        // then
+        XCTAssertTrue(previewDownloader.tornDown)
     }
     
     func testThatItReturnsTheDetectedLinkAndOffsetInAText() {

--- a/WireLinkPreviewTests/LinkPreviewDetectorTests.swift
+++ b/WireLinkPreviewTests/LinkPreviewDetectorTests.swift
@@ -38,7 +38,6 @@ class LinkPreviewDetectorTests: XCTestCase, LinkPreviewDetectorDelegate {
         sut = LinkPreviewDetector(
             previewDownloader: previewDownloader,
             imageDownloader: imageDownloader,
-            resultsQueue: .main,
             workerQueue: .main
         )
     }
@@ -222,18 +221,18 @@ class LinkPreviewDetectorTests: XCTestCase, LinkPreviewDetectorDelegate {
     
     func testThatItCallsTheCompletionClosureOnTheResultsQueue_LinkInText_NoData() {
         let text = "This is a sample containig a link: www.example.com"
-        assertThatItCallsTheCompletionClosureOnTheResultsQueue(withText: text)
+        assertThatItCallsTheCompletionClosure(withText: text)
     }
     
     func testThatItCallsTheCompletionClosureOnTheResultsQueue_LinkInText_Data() {
         let text = "This is a sample containig a link: www.example.com"
         previewDownloader.mockOpenGraphData = OpenGraphMockDataProvider.guardianData().expected!
-        assertThatItCallsTheCompletionClosureOnTheResultsQueue(withText: text)
+        assertThatItCallsTheCompletionClosure(withText: text)
     }
     
     func testThatItCallsTheCompletionClosureOnTheResultsQueue_NoLinkInText() {
         let text = "This is a sample not containig a link"
-        assertThatItCallsTheCompletionClosureOnTheResultsQueue(withText: text)
+        assertThatItCallsTheCompletionClosure(withText: text)
     }
     
     func testThatItImmediatelyCallsTheCompletionHandlerForHostsOnTheBlacklist() {
@@ -253,15 +252,14 @@ class LinkPreviewDetectorTests: XCTestCase, LinkPreviewDetectorDelegate {
         XCTAssertTrue(result.isEmpty)
     }
     
-    func assertThatItCallsTheCompletionClosureOnTheResultsQueue(withText text: String, line: UInt = #line) {
+    func assertThatItCallsTheCompletionClosure(withText text: String, line: UInt = #line) {
         // given
         let queue = OperationQueue()
-        sut = LinkPreviewDetector(previewDownloader: previewDownloader, imageDownloader: imageDownloader, resultsQueue: queue, workerQueue: queue)
+        sut = LinkPreviewDetector(previewDownloader: previewDownloader, imageDownloader: imageDownloader, workerQueue: queue)
         let completionExpectation = expectation(description: "It calls the completion closure")
         
         // when
         sut.downloadLinkPreviews(inText: text) { _ in
-            XCTAssertEqual(OperationQueue.current, queue, line: line)
             completionExpectation.fulfill()
         }
         

--- a/WireLinkPreviewTests/PreviewDownloaderTests.swift
+++ b/WireLinkPreviewTests/PreviewDownloaderTests.swift
@@ -38,6 +38,24 @@ class PreviewDownloaderTests: XCTestCase {
         sut = PreviewDownloader(resultsQueue: .main, parsingQueue: .main, urlSession: mockSession)
     }
 
+    override func tearDown() {
+        mockSession = nil
+        mockDataTask = nil
+        sut = nil
+        super.tearDown()
+    }
+
+    func testThatItInvalidatesSessionAfterTearDown() {
+        // given
+        XCTAssertFalse(mockSession.invalidated)
+
+        // when
+        sut.tearDown()
+
+        // then
+        XCTAssertTrue(mockSession.invalidated)
+    }
+
     func testThatItAsksTheSessionForADataTaskWhenOpenGraphDataIsRequested() {
         // given
         let completion: PreviewDownloader.DownloadCompletion = { _ in }

--- a/WireLinkPreviewTests/URLMocks.swift
+++ b/WireLinkPreviewTests/URLMocks.swift
@@ -63,4 +63,9 @@ class MockURLSession: URLSessionType {
             return mockDataTask!
         }
     }
+
+    var invalidated = false
+    func invalidateAndCancel() {
+        invalidated = true
+    }
 }


### PR DESCRIPTION
## What's new in this PR?

* Removed the `resultQueue` because it doesn't work too well with NSManagedObjectContext and where it is used the result immediately gets switched to MOC queue - https://github.com/wireapp/wire-ios-request-strategy/blob/develop/Sources/Request%20Strategies/Assets/Helpers/LinkPreviewPreprocessor.swift#L72-L77
* Added ability to tear down the PreviewDownloader. This is needed because it was leaking as NSURLSession holds to delegate strongly until it is invalidated.
