### PR TITLE
Rename LinkPreview to LinkMetadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ detector.downloadLinkPreviews(inText: text) { previews in
 }
 ```
 
-A call to this method will also download the images specified in the Open Graph data. The completion returns an array of `LinkPreview` objects which currently are either of type `Article` or `TwitterStatus`, while the count of elements in the array is also limited to one at for now. Note, use the delegate `LinkPreviewDetectorDelegate` to control which which detected links will have their preview generated.
+A call to this method will also download the images specified in the Open Graph data. The completion returns an array of `LinkPreview` objects which currently are either of type `ArticleMetadata` or `TwitterStatusMetadata`, while the count of elements in the array is also limited to one at for now. Note, use the delegate `LinkPreviewDetectorDelegate` to control which which detected links will have their preview generated.

--- a/WireLinkPreview/LinkPreviewDetector.swift
+++ b/WireLinkPreview/LinkPreviewDetector.swift
@@ -22,7 +22,7 @@ import WireUtilities
 
 public protocol LinkPreviewDetectorType {
     
-    func downloadLinkPreviews(inText text: String, excluding: [Range<Int>], completion: @escaping ([LinkPreview]) -> Void)
+    func downloadLinkPreviews(inText text: String, excluding: [Range<Int>], completion: @escaping ([LinkMetadata]) -> Void)
     
 }
 
@@ -34,7 +34,7 @@ public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
     private let imageDownloader: ImageDownloaderType
     private let workerQueue: OperationQueue
     
-    public typealias DetectCompletion = ([LinkPreview]) -> Void
+    public typealias DetectCompletion = ([LinkMetadata]) -> Void
     typealias URLWithRange = (URL: URL, range: NSRange)
     
     public convenience override init() {

--- a/WireLinkPreview/LinkPreviewTypes.swift
+++ b/WireLinkPreview/LinkPreviewTypes.swift
@@ -20,7 +20,7 @@
 import Foundation
 
 
-@objcMembers open class LinkPreview : NSObject {
+@objcMembers open class LinkMetadata : NSObject {
     
     public let originalURLString: String
     public let permanentURL: URL?
@@ -51,24 +51,24 @@ import Foundation
 }
 
 
-@objcMembers public class Article : LinkPreview {
+@objcMembers public class ArticleMetadata : LinkMetadata {
     public var title : String?
     public var summary : String?
 }
 
-@objcMembers public class FoursquareLocation : LinkPreview {
+@objcMembers public class FoursquareLocationMetadata : LinkMetadata {
     public var title : String?
     public var subtitle : String?
     public var latitude: Float?
     public var longitude: Float?
 }
 
-@objcMembers public class InstagramPicture : LinkPreview {
+@objcMembers public class InstagramPictureMetadata : LinkMetadata {
     public var title : String?
     public var subtitle : String?
 }
 
-@objcMembers public class TwitterStatus : LinkPreview {
+@objcMembers public class TwitterStatusMetadata : LinkMetadata {
     public var message : String?
     public var username : String?
     public var author : String?

--- a/WireLinkPreview/OpenGraphData.swift
+++ b/WireLinkPreview/OpenGraphData.swift
@@ -109,7 +109,7 @@ public func ==(lhs: FoursquareMetaData, rhs: FoursquareMetaData) -> Bool {
     return lhs.latitude == rhs.latitude && lhs.longitude == rhs.longitude
 }
 
-extension Article {
+extension ArticleMetadata {
     public convenience init(openGraphData: OpenGraphData, originalURLString: String, offset: Int) {
         self.init(originalURLString: originalURLString, permanentURLString: openGraphData.url, resolvedURLString: openGraphData.resolvedURL, offset: offset)
         title = openGraphData.title
@@ -119,7 +119,7 @@ extension Article {
     }
 }
 
-extension FoursquareLocation {
+extension FoursquareLocationMetadata {
     public convenience init?(openGraphData: OpenGraphData, originalURLString: String, offset: Int) {
         guard openGraphData.type  == OpenGraphTypeType.foursquare.rawValue && openGraphData.siteName == .foursquare else { return nil }
         
@@ -133,7 +133,7 @@ extension FoursquareLocation {
     }
 }
 
-extension InstagramPicture {
+extension InstagramPictureMetadata {
     public convenience init?(openGraphData: OpenGraphData, originalURLString: String, offset: Int) {
         guard openGraphData.type == OpenGraphTypeType.instagram.rawValue && openGraphData.siteName == .instagram else { return nil }
         self.init(originalURLString: originalURLString, permanentURLString: openGraphData.url, resolvedURLString: openGraphData.resolvedURL, offset: offset)
@@ -144,7 +144,7 @@ extension InstagramPicture {
     }
 }
 
-extension TwitterStatus {
+extension TwitterStatusMetadata {
 
     public convenience init?(openGraphData: OpenGraphData, originalURLString: String, offset: Int) {
         guard openGraphData.type == OpenGraphTypeType.article.rawValue && openGraphData.siteName == .twitter else { return nil }
@@ -170,9 +170,9 @@ extension TwitterStatus {
 
 extension OpenGraphData  {
     
-    func linkPreview(_ originalURLString: String, offset: Int) -> LinkPreview {
-        return TwitterStatus(openGraphData: self, originalURLString: originalURLString, offset: offset) ??
-            Article(openGraphData: self, originalURLString: originalURLString, offset: offset)
+    func linkPreview(_ originalURLString: String, offset: Int) -> LinkMetadata {
+        return TwitterStatusMetadata(openGraphData: self, originalURLString: originalURLString, offset: offset) ??
+            ArticleMetadata(openGraphData: self, originalURLString: originalURLString, offset: offset)
     }
     
 }

--- a/WireLinkPreviewTests/LinkPreviewDetectorTests.swift
+++ b/WireLinkPreviewTests/LinkPreviewDetectorTests.swift
@@ -154,7 +154,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         let completionExpectation = expectation(description: "It calls the completion closure")
 
         // when
-        var result = [LinkPreview]()
+        var result = [LinkMetadata]()
         sut.downloadLinkPreviews(inText: text) {
             result = $0
             completionExpectation.fulfill()
@@ -184,7 +184,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         let completionExpectation = expectation(description: "It calls the completion closure")
         
         // when
-        var result = [LinkPreview]()
+        var result = [LinkMetadata]()
         sut.downloadLinkPreviews(inText: text) {
             result = $0
             completionExpectation.fulfill()
@@ -205,7 +205,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         previewDownloader.mockOpenGraphData = openGraphData
         
         // when
-        var result = [LinkPreview]()
+        var result = [LinkMetadata]()
         sut.downloadLinkPreviews(inText: text) {
             result = $0
             completionExpectation.fulfill()
@@ -215,7 +215,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         waitForExpectations(timeout: 0.2, handler: nil)
         XCTAssertEqual(imageDownloader.downloadImageCallCount, 1)
         XCTAssertEqual(result.first?.imageURLs.first?.absoluteString, openGraphData.imageUrls.first)
-        guard let article = result.first as? Article else { return XCTFail("Wrong preview type") }
+        guard let article = result.first as? ArticleMetadata else { return XCTFail("Wrong preview type") }
         XCTAssertEqual(article.permanentURL?.absoluteString, openGraphData.url)
         XCTAssertEqual(article.originalURLString, "example.com")
         XCTAssertEqual(article.characterOffsetInText, 35)
@@ -230,7 +230,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         previewDownloader.mockOpenGraphData = openGraphData
         
         // when
-        var result = [LinkPreview]()
+        var result = [LinkMetadata]()
         sut.downloadLinkPreviews(inText: text) {
             result = $0
             completionExpectation.fulfill()
@@ -241,7 +241,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         XCTAssertEqual(imageDownloader.downloadImageCallCount, 1)
         XCTAssertEqual(imageDownloader.downloadImagesCallCount, 0)
 
-        guard let twitterStatus = result.first as? TwitterStatus else { return XCTFail("Wrong preview type") }
+        guard let twitterStatus = result.first as? TwitterStatusMetadata else { return XCTFail("Wrong preview type") }
         XCTAssertEqual(twitterStatus.imageURLs.count, 4)
         XCTAssertEqual(twitterStatus.imageURLs.map { $0.absoluteString }, openGraphData.imageUrls)
         XCTAssertEqual(twitterStatus.characterOffsetInText, 35)
@@ -270,7 +270,7 @@ class LinkPreviewDetectorTests: XCTestCase {
         // given
         let url = "www.soundcloud.com"
         let completionExpectation = expectation(description: "It calls the completion closure")
-        var result = [LinkPreview]()
+        var result = [LinkMetadata]()
         
         // when
         sut.downloadLinkPreviews(inText: url) {

--- a/WireLinkPreviewTests/OpenGraphDataTests.swift
+++ b/WireLinkPreviewTests/OpenGraphDataTests.swift
@@ -80,27 +80,27 @@ class OpenGraphDataTests: XCTestCase {
     }
     
     func testThatItCreatesTheCorrectLinkPreview_Twitter() {
-        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.twitterData(), expectedClass: TwitterStatus.self)
+        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.twitterData(), expectedClass: TwitterStatusMetadata.self)
     }
     
     func testThatItCreatesTheCorrectLinkPreview_TwitterWithImages() {
-        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.twitterDataWithImages(), expectedClass: TwitterStatus.self)
+        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.twitterDataWithImages(), expectedClass: TwitterStatusMetadata.self)
     }
     
     func testThatItCreatesTheCorrectLinkPreview_TheVerge() {
-        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.vergeData(), expectedClass: Article.self)
+        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.vergeData(), expectedClass: ArticleMetadata.self)
     }
     
     func testThatItCreatesTheCorrectLinkPreview_Foursqaure() {
-        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.foursquareData(), expectedClass: Article.self)
+        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.foursquareData(), expectedClass: ArticleMetadata.self)
     }
     
     func testThatItCreatesTheCorrectLinkPreview_Nytimes() {
-        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.nytimesData(), expectedClass: Article.self)
+        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.nytimesData(), expectedClass: ArticleMetadata.self)
     }
     
     func testThatItCreatesTheCorrectLinkPreview_Guardian() {
-        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.guardianData(), expectedClass: Article.self)
+        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.guardianData(), expectedClass: ArticleMetadata.self)
     }
     
     func testThatItCreatesTheCorrectLinkPreview_Youtube() {
@@ -112,31 +112,31 @@ class OpenGraphDataTests: XCTestCase {
     }
     
     func testThatItCreatesTheCorrectLinkPreview_Instagram() {
-        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.instagramData(), expectedClass: Article.self)
+        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.instagramData(), expectedClass: ArticleMetadata.self)
     }
     
     func testThatItCreatesTheCorrectLinkPreview_WashingtonPost() {
-        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.washingtonPostData(), expectedClass: Article.self)
+        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.washingtonPostData(), expectedClass: ArticleMetadata.self)
     }
     
     func testThatItCreatesTheCorrectLinkPreview_Medium() {
-        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.mediumData(), expectedClass: Article.self)
+        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.mediumData(), expectedClass: ArticleMetadata.self)
     }
     
     func testThatItCreatesTheCorrectLinkPreview_Polygon() {
-        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.polygonData(), expectedClass: Article.self)
+        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.polygonData(), expectedClass: ArticleMetadata.self)
     }
 
     func testThatItCreatesTheCorrectLinkPreview_iTunes() {
-        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.iTunesData(), expectedClass: Article.self)
+        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.iTunesData(), expectedClass: ArticleMetadata.self)
     }
 
     func testThatItCreatesTheCorrectLinkPreview_iTunesWithoutTitle() {
-        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.iTunesDataWithoutTitle(), expectedClass: Article.self)
+        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.iTunesDataWithoutTitle(), expectedClass: ArticleMetadata.self)
     }
     
     func testThatItCreatesTheCorrectLinkPreview_YahooSports() {
-        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.yahooSports(), expectedClass: Article.self)
+        assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.yahooSports(), expectedClass: ArticleMetadata.self)
     }
     
     func testThatItUsesTheGivenOriginalURLAndCharacterOffsetWhenCreatingALinkPreview() {
@@ -170,7 +170,7 @@ class OpenGraphDataTests: XCTestCase {
         XCTAssertEqual(sut.siteNameString, siteNameString, line: line)
     }
     
-    func assertLinkPreviewMapping(ofOpenGraphData openGraphData: OpenGraphMockData, expectedClass: AnyClass = LinkPreview.self, expectedFailure: Bool = false, line: UInt = #line) {
+    func assertLinkPreviewMapping(ofOpenGraphData openGraphData: OpenGraphMockData, expectedClass: AnyClass = LinkMetadata.self, expectedFailure: Bool = false, line: UInt = #line) {
         if let linkPreview = openGraphData.expected?.linkPreview(openGraphData.urlString, offset: 12) {
             XCTAssertFalse(expectedFailure, line: line)
             XCTAssertTrue(linkPreview.isKind(of: expectedClass), "Wrong class", line: line)


### PR DESCRIPTION
## What's new in this PR?

### Issues

When https://github.com/wireapp/wire-ios-protos/pull/27 is merged we will have naming clashes between classes in this framework and messages inside protobuf.

### Solutions

To avoid refactoring other frameworks too much we decided to rename several classes inside this framework:
* `LinkPreview` to `LinkMetadata`
* `Article` to `ArticleMetadata`
* `FoursquareLocation` to `FoursquareLocationMetadata`
* `InstagramPicture` to `InstagramPictureMetadata`
*  `TwitterStatus` to `TwitterStatusMetadata`
