### PR TITLE
Remove dependency on Ono

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,2 @@
-github "wireapp/ono" ~> 1.4
 github "wireapp/HTMLString" "4.0.2-xcode_10_1"
 github "wireapp/wire-ios-utilities" ~> 28.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,3 @@
 github "wireapp/HTMLString" "4.0.2-xcode_10_1"
-github "wireapp/ono" "1.4.0"
 github "wireapp/wire-ios-system" "26.0.1"
 github "wireapp/wire-ios-utilities" "28.2.0"

--- a/WireLinkPreview.xcodeproj/project.pbxproj
+++ b/WireLinkPreview.xcodeproj/project.pbxproj
@@ -8,11 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		16A5FE18215A87F500AEEBBD /* HTMLString.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16A5FE11215A87B600AEEBBD /* HTMLString.framework */; };
-		16A5FE19215A87F500AEEBBD /* Ono.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16A5FE13215A87B600AEEBBD /* Ono.framework */; };
 		16A5FE1A215A87F500AEEBBD /* WireSystem.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16A5FE10215A87B600AEEBBD /* WireSystem.framework */; };
 		16A5FE1B215A87F500AEEBBD /* WireUtilities.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16A5FE12215A87B600AEEBBD /* WireUtilities.framework */; };
 		16A5FE1C215A882700AEEBBD /* HTMLString.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 16A5FE11215A87B600AEEBBD /* HTMLString.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		16A5FE1D215A882700AEEBBD /* Ono.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 16A5FE13215A87B600AEEBBD /* Ono.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		16A5FE1E215A882700AEEBBD /* WireSystem.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 16A5FE10215A87B600AEEBBD /* WireSystem.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		16A5FE1F215A882700AEEBBD /* WireUtilities.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 16A5FE12215A87B600AEEBBD /* WireUtilities.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5E2BEC54214BA4A600E65B53 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2BEC53214BA4A600E65B53 /* AppDelegate.swift */; };
@@ -30,6 +28,9 @@
 		5E9EA4CE2242785900D401B2 /* LinkAttachmentDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9EA4CD2242785900D401B2 /* LinkAttachmentDetectorTests.swift */; };
 		5E9EA4D022427BBB00D401B2 /* soundcloud_track_head.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5E9EA4CF22427BBB00D401B2 /* soundcloud_track_head.txt */; };
 		5E9EA4D222427E0300D401B2 /* soundcloud_playlist_head.txt in Resources */ = {isa = PBXBuildFile; fileRef = 5E9EA4D122427E0300D401B2 /* soundcloud_playlist_head.txt */; };
+		5EDF03F12249287B00C04007 /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 5EDF03F02249287B00C04007 /* libxml2.tbd */; };
+		5EDF03F22249316B00C04007 /* libxml2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 5EDF03F02249287B00C04007 /* libxml2.tbd */; };
+		5EDF03F4224A208E00C04007 /* HTMLDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EDF03F3224A208E00C04007 /* HTMLDocument.swift */; };
 		87B48ECB20A088F700DBAD9D /* crash_emoji.txt in Resources */ = {isa = PBXBuildFile; fileRef = 87B48ECA20A088F700DBAD9D /* crash_emoji.txt */; };
 		BF21CC8D1E925AA300A874F5 /* foursquare_head.txt in Resources */ = {isa = PBXBuildFile; fileRef = BF21CC6D1E925A9E00A874F5 /* foursquare_head.txt */; };
 		BF21CC8E1E925AA300A874F5 /* guardian_head.txt in Resources */ = {isa = PBXBuildFile; fileRef = BF21CC6E1E925A9E00A874F5 /* guardian_head.txt */; };
@@ -99,7 +100,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				16A5FE1C215A882700AEEBBD /* HTMLString.framework in CopyFiles */,
-				16A5FE1D215A882700AEEBBD /* Ono.framework in CopyFiles */,
 				16A5FE1E215A882700AEEBBD /* WireSystem.framework in CopyFiles */,
 				16A5FE1F215A882700AEEBBD /* WireUtilities.framework in CopyFiles */,
 			);
@@ -133,6 +133,8 @@
 		5E9EA4CD2242785900D401B2 /* LinkAttachmentDetectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkAttachmentDetectorTests.swift; sourceTree = "<group>"; };
 		5E9EA4CF22427BBB00D401B2 /* soundcloud_track_head.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = soundcloud_track_head.txt; sourceTree = "<group>"; };
 		5E9EA4D122427E0300D401B2 /* soundcloud_playlist_head.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = soundcloud_playlist_head.txt; sourceTree = "<group>"; };
+		5EDF03F02249287B00C04007 /* libxml2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.tbd; path = usr/lib/libxml2.tbd; sourceTree = SDKROOT; };
+		5EDF03F3224A208E00C04007 /* HTMLDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTMLDocument.swift; sourceTree = "<group>"; };
 		87B48ECA20A088F700DBAD9D /* crash_emoji.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = crash_emoji.txt; sourceTree = "<group>"; };
 		BF21CC6D1E925A9E00A874F5 /* foursquare_head.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = foursquare_head.txt; path = WireLinkPreviewTests/foursquare_head.txt; sourceTree = SOURCE_ROOT; };
 		BF21CC6E1E925A9E00A874F5 /* guardian_head.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = guardian_head.txt; path = WireLinkPreviewTests/guardian_head.txt; sourceTree = SOURCE_ROOT; };
@@ -205,8 +207,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5EDF03F12249287B00C04007 /* libxml2.tbd in Frameworks */,
 				16A5FE18215A87F500AEEBBD /* HTMLString.framework in Frameworks */,
-				16A5FE19215A87F500AEEBBD /* Ono.framework in Frameworks */,
 				16A5FE1A215A87F500AEEBBD /* WireSystem.framework in Frameworks */,
 				16A5FE1B215A87F500AEEBBD /* WireUtilities.framework in Frameworks */,
 			);
@@ -216,6 +218,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5EDF03F22249316B00C04007 /* libxml2.tbd in Frameworks */,
 				BFF057951D25434E004A2C29 /* WireLinkPreview.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -226,6 +229,7 @@
 		16A5FE0F215A868700AEEBBD /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				5EDF03F02249287B00C04007 /* libxml2.tbd */,
 				16A5FE11215A87B600AEEBBD /* HTMLString.framework */,
 				16A5FE13215A87B600AEEBBD /* Ono.framework */,
 				16A5FE10215A87B600AEEBBD /* WireSystem.framework */,
@@ -364,6 +368,7 @@
 				BF4F2B371E925AC9000B22D1 /* URLSessionProtocols.swift */,
 				5E9EA4B62241426A00D401B2 /* NSDataDetector+Links.swift */,
 				5E9EA4C52242503E00D401B2 /* NSDataDetector+LinkAttachments.swift */,
+				5EDF03F3224A208E00C04007 /* HTMLDocument.swift */,
 				BF4F2B2D1E925AC9000B22D1 /* Info.plist */,
 			);
 			path = WireLinkPreview;
@@ -567,6 +572,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5EDF03F4224A208E00C04007 /* HTMLDocument.swift in Sources */,
 				BF4F2B3F1E925AC9000B22D1 /* OpenGraphDataTypes.swift in Sources */,
 				BF4F2B401E925AC9000B22D1 /* OpenGraphScanner.swift in Sources */,
 				BF4F2B3C1E925AC9000B22D1 /* LinkPreviewTypes.swift in Sources */,
@@ -791,6 +797,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BF3DD2801D25445600D51DED /* WireLinkPreview.xcconfig */;
 			buildSettings = {
+				HEADER_SEARCH_PATHS = "${SDKROOT}/usr/include/libxml2";
 				INFOPLIST_FILE = "$(SRCROOT)/WireLinkPreview/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.wire.WireLinkPreview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -802,6 +809,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BF3DD2801D25445600D51DED /* WireLinkPreview.xcconfig */;
 			buildSettings = {
+				HEADER_SEARCH_PATHS = "${SDKROOT}/usr/include/libxml2";
 				INFOPLIST_FILE = "$(SRCROOT)/WireLinkPreview/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = com.wire.WireLinkPreview;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -813,6 +821,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BF3DD2731D25445600D51DED /* ios-test-target.xcconfig */;
 			buildSettings = {
+				HEADER_SEARCH_PATHS = "${SDKROOT}/usr/include/libxml2";
 				INFOPLIST_FILE = WireLinkPreviewTests/Info.plist;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;
@@ -824,6 +833,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BF3DD2731D25445600D51DED /* ios-test-target.xcconfig */;
 			buildSettings = {
+				HEADER_SEARCH_PATHS = "${SDKROOT}/usr/include/libxml2";
 				INFOPLIST_FILE = WireLinkPreviewTests/Info.plist;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.2;

--- a/WireLinkPreview/HTMLDocument.swift
+++ b/WireLinkPreview/HTMLDocument.swift
@@ -32,8 +32,11 @@ class HTMLDocument {
     /// Tries to parse the content of an XML string.
     init?(string: String) {
         let options = Int32(HTML_PARSE_NOWARNING.rawValue) | Int32(HTML_PARSE_NOERROR.rawValue) | Int32(HTML_PARSE_RECOVER.rawValue)
-        let decodedDocument: xmlDocPtr? = Data(string.utf8).withUnsafeBytes { (xmlData: UnsafePointer<Int8>) in
-            return htmlReadMemory(xmlData, Int32(string.utf8.count), "", "UTF-8", options)
+        let stringLength = string.utf8.count
+        let decodedDocument = string.withCString(encodedAs: UTF8.self) { (xmlData: UnsafePointer<UInt8>) in
+            xmlData.withMemoryRebound(to: Int8.self, capacity: stringLength) {
+                return htmlReadMemory($0, Int32(stringLength), "", "UTF-8", options)
+            }
         }
 
         guard let rawPtr = decodedDocument else { return nil }

--- a/WireLinkPreview/HTMLDocument.swift
+++ b/WireLinkPreview/HTMLDocument.swift
@@ -1,0 +1,184 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import HTMLString
+import libxml2
+
+// MARK: Models
+
+/**
+ * Wrapper around a `xmlDocPtr`, that represents an HTML document.
+ */
+
+class HTMLDocument {
+    let rawPtr: xmlDocPtr
+
+    /// Tries to parse the content of an XML string.
+    init?(string: String) {
+        let options = Int32(HTML_PARSE_NOWARNING.rawValue) | Int32(HTML_PARSE_NOERROR.rawValue) | Int32(HTML_PARSE_RECOVER.rawValue)
+        let decodedDocument: xmlDocPtr? = Data(string.utf8).withUnsafeBytes { (xmlData: UnsafePointer<Int8>) in
+            return htmlReadMemory(xmlData, Int32(string.utf8.count), "", "UTF-8", options)
+        }
+
+        guard let rawPtr = decodedDocument else { return nil }
+        self.rawPtr = rawPtr
+    }
+
+    deinit {
+        xmlFreeDoc(rawPtr)
+    }
+
+    /// Returns the root element of the document.
+    var rootElement: HTMLElement? {
+        guard let rootPtr = xmlDocGetRootElement(rawPtr) else { return nil }
+        return HTMLElement(rawPtr: rootPtr)
+    }
+}
+
+/**
+ * Wrapper around a `xmlNodePtr`, that represents an element in an HTML DOM tree.
+ */
+
+class HTMLElement {
+    let rawPtr: xmlNodePtr
+
+    init(rawPtr: xmlNodePtr) {
+        self.rawPtr = rawPtr
+    }
+
+    /// The name of the HTML tag.
+    var tagName: HTMLStringBuffer {
+        return HTMLStringBuffer(rawPtr.pointee.name)
+    }
+
+    /// The textual content of the element.
+    var content: HTMLStringBuffer? {
+        guard let text = xmlNodeGetContent(rawPtr) else { return nil }
+        return HTMLStringBuffer(text)
+    }
+
+    /// The children of the element, as an iterable sequence.
+    var children: HTMLChildrenSequence {
+        let iterator = HTMLChildrenIterator(rootElement: self)
+        return HTMLChildrenSequence(iterator)
+    }
+
+    /// The attributes of the element.
+    var attributes: HTMLAttributesContainer {
+        return HTMLAttributesContainer(element: self)
+    }
+}
+
+// MARK: - Helper Types
+
+/// A sequence of HTML elements.
+typealias HTMLChildrenSequence = IteratorSequence<HTMLChildrenIterator>
+
+class HTMLChildrenIterator: IteratorProtocol {
+    let rootElement: HTMLElement
+    let numberOfChildren: UInt
+    var currentChild: HTMLElement?
+
+    init(rootElement: HTMLElement) {
+        self.rootElement = rootElement
+        self.numberOfChildren = xmlChildElementCount(rootElement.rawPtr)
+        self.currentChild = nil
+    }
+
+    func next() -> HTMLElement? {
+        guard numberOfChildren > 0 else {
+            return nil
+        }
+
+        let nextPtr: xmlNodePtr?
+
+        if let currentChild = self.currentChild {
+            nextPtr = xmlNextElementSibling(currentChild.rawPtr)
+        } else {
+            nextPtr = xmlFirstElementChild(rootElement.rawPtr)
+        }
+
+        currentChild = nextPtr.map(HTMLElement.init)
+        return currentChild
+    }
+}
+
+/**
+ * Wrapper to access the elements of an HTML element through subscripting.
+ */
+
+class HTMLAttributesContainer {
+    let element: HTMLElement
+
+    init(element: HTMLElement) {
+        self.element = element
+    }
+
+    subscript(attributeName: String) -> HTMLStringBuffer? {
+        guard let xmlProp = xmlGetProp(element.rawPtr, attributeName) else { return nil }
+        return HTMLStringBuffer(xmlProp)
+    }
+}
+
+/**
+ * Wrapper around a `xmlCharPtr`, that represents an HTML string.
+ */
+
+class HTMLStringBuffer {
+    enum Storage {
+        case retained(UnsafeMutablePointer<xmlChar>)
+        case unowned(UnsafePointer<xmlChar>)
+
+        var ptr: UnsafePointer<xmlChar> {
+            switch self {
+            case .retained(let ptr): return UnsafePointer(ptr)
+            case .unowned(let ptr): return ptr
+            }
+        }
+    }
+
+    let storage: Storage
+
+    /// Creates a new string wrapper.
+    init(_ ptr: UnsafePointer<xmlChar>) {
+        self.storage = .unowned(ptr)
+    }
+
+    /// Creates a new string wrapper.
+    init(_ ptr: UnsafeMutablePointer<xmlChar>) {
+        self.storage = .retained(ptr)
+    }
+
+    deinit {
+        if case let .retained(ptr) = storage {
+            xmlFree(ptr)
+        }
+    }
+
+    /// Returns the value of the string, with unescaped HTML entities.
+    var stringValue: String {
+        return String(cString: storage.ptr).removingHTMLEntities
+    }
+
+}
+
+/// Compares an HTML string with an UTF-8 Swift string.
+func == (lhs: HTMLStringBuffer, rhs: String) -> Bool {
+    return xmlStrEqual(lhs.storage.ptr, rhs) == 1
+}

--- a/WireLinkPreview/OpenGraphDataTypes.swift
+++ b/WireLinkPreview/OpenGraphDataTypes.swift
@@ -19,9 +19,9 @@
 
 import Foundation
 
-enum OpenGraphAttribute: String {
-    case property = "property"
-    case content = "content"
+enum OpenGraphAttribute {
+    static let property = "property"
+    static let content = "content"
 }
 
 enum OpenGraphXMLNode: String {

--- a/WireLinkPreview/OpenGraphScanner.swift
+++ b/WireLinkPreview/OpenGraphScanner.swift
@@ -38,7 +38,8 @@ final class OpenGraphScanner: NSObject {
     
     func parse() {
         // 1. Parse the document
-        guard let document = HTMLDocument(string: xmlString) else { return completion(nil) }
+        guard let document = HTMLDocument(xmlString: xmlString) else { return completion(nil) }
+        defer { HTMLDocument.free(document) }
 
         // 2. Find the head
         guard let headElement = findHead(in: document) else { return completion(nil) }
@@ -71,11 +72,9 @@ final class OpenGraphScanner: NSObject {
 
     /// Attempts to extract the OpenGraph metadata from an HTML element.
     private func parseOpenGraphMetadata(_ element: HTMLElement) {
-        let attributes = element.attributes
-
-        if let rawProperty = attributes[OpenGraphAttribute.property]?.stringValue,
+        if let rawProperty = element[attribute: OpenGraphAttribute.property]?.stringValue,
             let property = OpenGraphPropertyType(rawValue: rawProperty),
-            let content = attributes[OpenGraphAttribute.content]?.stringValue
+            let content = element[attribute: OpenGraphAttribute.content]?.stringValue
         {
             addProperty(property, value: content)
         }

--- a/WireLinkPreview/OpenGraphScanner.swift
+++ b/WireLinkPreview/OpenGraphScanner.swift
@@ -47,7 +47,7 @@ final class OpenGraphScanner: NSObject {
         // 3. Go through the attributes
         for headChild in headElement.children {
             if headChild.tagName == "title" {
-                pageTitle = headChild.content?.stringValue
+                pageTitle = headChild.content?.stringValue(removingEntities: true)
             } else if headChild.tagName == "meta" {
                 parseOpenGraphMetadata(headChild)
             }
@@ -72,9 +72,9 @@ final class OpenGraphScanner: NSObject {
 
     /// Attempts to extract the OpenGraph metadata from an HTML element.
     private func parseOpenGraphMetadata(_ element: HTMLElement) {
-        if let rawProperty = element[attribute: OpenGraphAttribute.property]?.stringValue,
+        if let rawProperty = element[attribute: OpenGraphAttribute.property]?.stringValue(removingEntities: false),
             let property = OpenGraphPropertyType(rawValue: rawProperty),
-            let content = element[attribute: OpenGraphAttribute.content]?.stringValue
+            let content = element[attribute: OpenGraphAttribute.content]?.stringValue(removingEntities: true)
         {
             addProperty(property, value: content)
         }

--- a/WireLinkPreview/OpenGraphScanner.swift
+++ b/WireLinkPreview/OpenGraphScanner.swift
@@ -16,9 +16,7 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
-import Ono
-import HTMLString
+import Foundation
 
 final class OpenGraphScanner: NSObject {
     
@@ -27,9 +25,10 @@ final class OpenGraphScanner: NSObject {
     let xmlString: String
     var contentsByProperty = [OpenGraphPropertyType: String]()
     var images = [String]()
+    var pageTitle: String?
     var completion: ParserCompletion
     var originalURL: URL
-    
+
     init(_ xmlString: String, url: URL, completion: @escaping ParserCompletion) {
         self.xmlString = xmlString
         self.completion = completion
@@ -38,34 +37,63 @@ final class OpenGraphScanner: NSObject {
     }
     
     func parse() {
-        guard let document = try? ONOXMLDocument.htmlDocument(with: xmlString, encoding: String.Encoding.utf8.rawValue) else { return }
-        parseXML(document)
-        createObjectAndComplete(document)
+        // 1. Parse the document
+        guard let document = HTMLDocument(string: xmlString) else { return completion(nil) }
+
+        // 2. Find the head
+        guard let headElement = findHead(in: document) else { return completion(nil) }
+
+        // 3. Go through the attributes
+        for headChild in headElement.children {
+            if headChild.tagName == "title" {
+                pageTitle = headChild.content?.stringValue
+            } else if headChild.tagName == "meta" {
+                parseOpenGraphMetadata(headChild)
+            }
+        }
+
+        // 4. Finish parsing
+        createObjectAndComplete()
     }
 
-    private func parseXML(_ xmlDocument: ONOXMLDocument) {
-        xmlDocument.enumerateElements(withXPath: "//meta", using: { [weak self] (element, _, _) in
-            guard let `self` = self,
-                let property = element?[OpenGraphAttribute.property.rawValue] as? String,
-                let content = element?[OpenGraphAttribute.content.rawValue] as? String,
-                let type = OpenGraphPropertyType(rawValue: property) else { return }
+    // MARK: - Parsing
 
-            self.addProperty(type, value: content)
-        })
-    }
-    
-    private func addProperty(_ property: OpenGraphPropertyType, value: String) {
-        let content = value.removingHTMLEntities
-        if property == .image {
-            images.append(content)
+    /// Returns the first head element in the document.
+    private func findHead(in document: HTMLDocument) -> HTMLElement? {
+        guard let rootElement = document.rootElement else { return nil }
+
+        if rootElement.tagName == "head" {
+            return rootElement
         } else {
-            contentsByProperty[property] = content
+            return rootElement.children.first(where: { $0.tagName == "head" })
         }
     }
 
-    private func createObjectAndComplete(_ xmlDocument: ONOXMLDocument) {
+    /// Attempts to extract the OpenGraph metadata from an HTML element.
+    private func parseOpenGraphMetadata(_ element: HTMLElement) {
+        let attributes = element.attributes
+
+        if let rawProperty = attributes[OpenGraphAttribute.property]?.stringValue,
+            let property = OpenGraphPropertyType(rawValue: rawProperty),
+            let content = attributes[OpenGraphAttribute.content]?.stringValue
+        {
+            addProperty(property, value: content)
+        }
+    }
+
+    private func addProperty(_ property: OpenGraphPropertyType, value: String) {
+        if property == .image {
+            images.append(value)
+        } else {
+            contentsByProperty[property] = value
+        }
+    }
+
+    // MARK: - Post-Processing
+
+    private func createObjectAndComplete() {
         insertMissingUrlIfNeeded()
-        insertMissingTitleIfNeeded(xmlDocument)
+        insertMissingTitleIfNeeded()
         let data = OpenGraphData(propertyMapping: contentsByProperty, resolvedURL: originalURL, images: images)
         completion(data)
     }
@@ -75,12 +103,9 @@ final class OpenGraphScanner: NSObject {
         contentsByProperty[.url] = originalURL.absoluteString
     }
 
-    private func insertMissingTitleIfNeeded(_ xmlDocument: ONOXMLDocument) {
+    private func insertMissingTitleIfNeeded() {
         guard !contentsByProperty.keys.contains(.title) else { return }
-        xmlDocument.enumerateElements(withXPath: "//title", using: { [weak self] (element, _, stop) in
-            guard let `self` = self, let value = element?.stringValue() else { return }
-            self.addProperty(.title, value: value)
-            stop?.pointee = ObjCBool(true)
-        })
+        pageTitle.map { addProperty(.title, value: $0) }
     }
+
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

We use Ono to parse the HTML documents to fetch link previews. This library provides syntactic sugar to interact with `libxml2`. For our use case (detecting the head, title and meta tags), its use of Xpath and other generalizations was a bit of overkill and could be replaced by simpler homegrown solution.

### Solutions

- Use libxml2 directly
- Add wrappers around libxml2 for more efficient memory management and type safety.
    - `HTMLDocument`: initialization of the `xmlDocPtr` with a String, finding the root element, freeing the pointer
    - `HTMLElement`: getting the tag name, finding attributes and children
    - `HTMLChildrenIterator`: walking a sequence of children from a node as a native `Sequence`
    - `HTMLStringBuffer`: helper to manage references to an `xmlChar` buffer, comparing and converting to Swift strings.

We needed to do small updates the OpenGraph scanner to use this new APIs.

### Benchmark

Methodology: We ran the decoding of the mock data in `OpenGraphScannerTests` each 100 times and calculated the average, comparing Ono and our solution in Debug mode (without optimization).

| Test data | LinkPreview implementation | Ono implementation | Speed Gain in new version |
|----------|-----------------------------|---------------------|---------------------------|
| Twitter | 0.0013s | 0.0011s | -0.0002s |
| Twitter (with image) | 0.0013s | 0.0012s | -0.0001s |
| The Verge | 0.00075s | 0.00073s | -0.00002s |
| Foursquare | 0.00079s | 0.00075s | -0.00004s |
| YouTube | 0.00079s | 0.00061s | -0.00018s |
| The Guardian | 0.014s | 0.013s | -0.001s |
| Instagram | 0.00074s | 0.00073s | -0.00001s |
| Vimeo | 0.0008s | 0.0006s | -0.0002s |
| NY Times | 0.0008s | 0.0009s | **+0.0001s** |
| WashPost | 0.0005s | 0.0005s | N/A |
| Wire | 0.0002 | 0.0002s | N/A |
| Polygon | 0.0005s | 0.0005s | N/A |
| iTunes | 0.0008s | 0.0007s | -0.0001s |
| iTunes (fallback title) | 0.0008s | 0.0007s | -0.0001s |
| Yahoo Sports | 0.00069s | 0.00065s | -0.00004s |
| VK Post with numeric escape | 0.00007s | 0.00008s | **+0.00001s**  |

Speed gain is expressed in seconds gained relative to the Ono implementation.

We conclude that the performance between the two implementations is similar, and that removing the dependency will not have a negative impact on performance.