### PR TITLE
ZIOS-11059: Do not generate link previews for broken links

### DIFF
--- a/WireLinkPreview/PreviewDownloader.swift
+++ b/WireLinkPreview/PreviewDownloader.swift
@@ -150,12 +150,21 @@ extension PreviewDownloader {
         guard let url = dataTask.originalRequest?.url, let completion = completionByURL[url] else { return }
         let (headers, contentTypeKey) = (response.allHeaderFields, HeaderKey.contentType.rawValue)
         let contentType = headers[contentTypeKey] as? String ?? headers[contentTypeKey.lowercased()] as? String
-        if let contentType = contentType , !contentType.lowercased().contains("text/html") {
+        if let contentType = contentType , !contentType.lowercased().contains("text/html") || !response.isSuccess {
             completeAndCleanUp(completion, result: nil, url: url, taskIdentifier: dataTask.taskIdentifier)
             return completionHandler(.cancel)
         }
         
         return completionHandler(.allow)
+    }
+
+}
+
+extension HTTPURLResponse {
+
+    /// Whether the response is a success.
+    var isSuccess: Bool {
+        return statusCode < 400
     }
 
 }

--- a/WireLinkPreviewTests/IntegrationTests.swift
+++ b/WireLinkPreviewTests/IntegrationTests.swift
@@ -123,6 +123,11 @@ class IntegrationTests: XCTestCase {
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
 
+    func testThatItDoesNotParse404Links() {
+        let mockSite = OpenGraphMockData(head: "", expected: nil, urlString: "https://instagram.com/404", urlVersion: nil)
+        assertThatItCanParseSampleData(mockSite, expected: nil)
+    }
+
     struct OpenGraphDataExpectation {
         let numberOfImages: Int
         let type: String?
@@ -132,7 +137,7 @@ class IntegrationTests: XCTestCase {
         let hasFoursquareMetaData: Bool
     }
     
-    func assertThatItCanParseSampleData(_ mockData: OpenGraphMockData, expected: OpenGraphDataExpectation, line: UInt = #line) {
+    func assertThatItCanParseSampleData(_ mockData: OpenGraphMockData, expected: OpenGraphDataExpectation?, line: UInt = #line) {
 
         // given
         let completionExpectation = expectation(description: "It should parse the data")
@@ -151,11 +156,17 @@ class IntegrationTests: XCTestCase {
         var result: OpenGraphData?
         sut.requestOpenGraphData(fromURL: resolvedURL) { data in
             result = data
-            XCTAssertNotNil(data, line: line)
             completionExpectation.fulfill()
         }
 
         waitForExpectations(timeout: 60, handler: nil)
+
+        if expected == nil {
+            return XCTAssertNil(result, "Expected no OpenGraph data from \(mockData.urlString)", line: line)
+        }
+
+        let expected = expected!
+
         guard let data = result else {
             return XCTFail("Could not extract open graph data from \(mockData.urlString)", line: line)
         }

--- a/WireLinkPreviewTests/PreviewDownloaderTests.swift
+++ b/WireLinkPreviewTests/PreviewDownloaderTests.swift
@@ -226,6 +226,10 @@ class PreviewDownloaderTests: XCTestCase {
     func testThatItCallsTheCompletionHandlerAndCancelsTheRequestIfTheContentTypeOfTheResponseIfNotHTML() {
         assertThatItCallsTheDipositionHandler(.cancel, contentType: "something-other-than-html")
     }
+
+    func testThatItCallsTheCompletionHandlerAndCancelsTheRequestIfTheStatusIsNotSuccessful() {
+        assertThatItCallsTheDipositionHandler(.cancel, contentType: "text/html", statusCode: 404)
+    }
     
     func testThatItCallsTheDispositionHandlerWithAllowAndDoesNotCallTheDownloadCompletionForContentTypeHTML() {
         assertThatItCallsTheDipositionHandler(.allow, contentType: "text/html")
@@ -239,7 +243,7 @@ class PreviewDownloaderTests: XCTestCase {
         assertThatItCallsTheDipositionHandler(.allow, contentType: "TEXT/HTML")
     }
     
-    func assertThatItCallsTheDipositionHandler(_ expected: URLSession.ResponseDisposition, contentType: String, line: UInt = #line) {
+    func assertThatItCallsTheDipositionHandler(_ expected: URLSession.ResponseDisposition, contentType: String, statusCode: Int = 200, line: UInt = #line) {
         // given
         let downloadExpectation = expectation(description: "It should call the downloader completion handler")
         let sessionExpectation = expectation(description: "It should call the session completion handler")
@@ -251,7 +255,7 @@ class PreviewDownloaderTests: XCTestCase {
         // when
         let response = HTTPURLResponse(
             url: originalRequest.url!,
-            statusCode: 200,
+            statusCode: statusCode,
             httpVersion: nil,
             headerFields: ["Content-Type": contentType]
         )


### PR DESCRIPTION
## What's new in this PR?

### Issues

When a page was not found (e.g. a 404 page), we generated a link preview anyway. This was inconsistent with the behavior of other platforms.

### Solutions

Stop processing the link if the status code of the request indicates a failure (if code >= 400).