### PR TITLE
ZIOS-11330: Add blacklist property to link metadata

### DIFF
--- a/WireLinkPreview/LinkPreviewDetector.swift
+++ b/WireLinkPreview/LinkPreviewDetector.swift
@@ -28,7 +28,6 @@ public protocol LinkPreviewDetectorType {
 
 public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
     
-    private let blacklist = PreviewBlacklist()
     private let linkDetector : NSDataDetector? = NSDataDetector.linkDetector
     private let previewDownloader: PreviewDownloaderType
     private let imageDownloader: ImageDownloaderType
@@ -67,7 +66,7 @@ public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
      - parameter completion: The completion closure called when the link previews (and it's images) have been downloaded.
      */
     public func downloadLinkPreviews(inText text: String, excluding: [NSRange] = [], completion : @escaping DetectCompletion) {
-        guard let (url, range) = linkDetector?.detectLinksAndRanges(in: text, excluding: excluding).first, !blacklist.isBlacklisted(url) else { return completion([]) }
+        guard let (url, range) = linkDetector?.detectLinksAndRanges(in: text, excluding: excluding).first, !PreviewBlacklist.isBlacklisted(url) else { return completion([]) }
         previewDownloader.requestOpenGraphData(fromURL: url) { [weak self] openGraphData in
             guard let `self` = self, let substringRange = Range<String.Index>(range, in: text) else { return }
             let originalURLString = String(text[substringRange])

--- a/WireLinkPreview/LinkPreviewTypes.swift
+++ b/WireLinkPreview/LinkPreviewTypes.swift
@@ -38,6 +38,16 @@ import Foundation
         characterOffsetInText = offset
         super.init()
     }
+
+    @objc public var isBlacklisted: Bool {
+        if let permanentURL = permanentURL {
+            return PreviewBlacklist.isBlacklisted(permanentURL)
+        } else if let resolvedURL = resolvedURL {
+            return PreviewBlacklist.isBlacklisted(resolvedURL)
+        } else {
+            return false
+        }
+    }
     
     func requestAssets(withImageDownloader downloader: ImageDownloaderType, completion: @escaping DownloadCompletion) {
         guard let imageURL = imageURLs.first else { return completion(false) }

--- a/WireLinkPreview/PreviewBlacklist.swift
+++ b/WireLinkPreview/PreviewBlacklist.swift
@@ -19,9 +19,9 @@
 
 import Foundation
 
-final class PreviewBlacklist {
-    
-    private let blacklistedHosts = [
+enum PreviewBlacklist {
+
+    private static let blacklistedHosts = [
         "soundcloud",
         "youtube",
         "youtu.be",
@@ -30,7 +30,7 @@ final class PreviewBlacklist {
         "giphy"
     ]
     
-    func isBlacklisted(_ url: URL) -> Bool {
+    static func isBlacklisted(_ url: URL) -> Bool {
         return blacklistedHosts.contains { blacklisted in
             url.absoluteString.lowercased().contains(blacklisted)
         }

--- a/WireLinkPreviewTests/PreviewBlackListTests.swift
+++ b/WireLinkPreviewTests/PreviewBlackListTests.swift
@@ -21,25 +21,50 @@ import XCTest
 @testable import WireLinkPreview
 
 class PreviewBlackListTests: XCTestCase {
-    
-    var sut: PreviewBlacklist!
-    
+
+    var hosts: [String]!
+
     override func setUp() {
         super.setUp()
-        sut = PreviewBlacklist()
+        hosts = ["soundcloud", "spotify", "youtube", "giphy", "youtu.be", "y2u.be"]
     }
-    
-    func testThatCorrectHostsAreAllBlacklisted() {
-        let hosts = ["soundcloud", "spotify", "youtube", "giphy", "youtu.be", "y2u.be"]
 
+    override func tearDown() {
+        hosts = nil
+        super.tearDown()
+    }
+
+    func testThatCorrectHostsAreAllBlacklisted() {
         for host in hosts {
             assertThatHostIsBlacklisted(host)
         }
     }
-    
+
+    func testThatCorrectHostsAreBlacklistedInPreviewMetadata() {
+        for host in hosts {
+            assertThatPreviewMetadataIsBlacklisted(host)
+        }
+    }
+
+    func testThatAllowedHostsAreNotBlacklistedInPreview() {
+        assertThatPreviewMetadataIsNotBlacklisted("twitter.com")
+    }
+
+    // MARK: - Helpers
+
     func assertThatHostIsBlacklisted(_ host: String, line: UInt = #line) {
         let url = URL(string: "www.\(host).com/example")!
-        XCTAssertTrue(sut.isBlacklisted(url), "\(host) was not blacklisted", line: line)
+        XCTAssertTrue(PreviewBlacklist.isBlacklisted(url), "\(host) was not blacklisted", line: line)
     }
-    
+
+    func assertThatPreviewMetadataIsBlacklisted(_ host: String, line: UInt = #line) {
+        let metadata = LinkMetadata(originalURLString: "https://www.\(host).com/example", permanentURLString: "https://www.\(host).com/example", resolvedURLString: "https://www.\(host).com/example", offset: 0)
+        XCTAssertTrue(metadata.isBlacklisted, line: line)
+    }
+
+    func assertThatPreviewMetadataIsNotBlacklisted(_ host: String, line: UInt = #line) {
+        let metadata = LinkMetadata(originalURLString: "https://www.\(host).com/example", permanentURLString: "https://www.\(host).com/example", resolvedURLString: "https://www.\(host).com/example", offset: 0)
+        XCTAssertFalse(metadata.isBlacklisted, line: line)
+    }
+
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

We do not want to display YouTube/SoundCloud/Giphy link previews in the UI, or make them behave like link previews (i.g. with removing the trailing link from the text).

### Causes

The blacklist was only honored when fetching link previews. There was no way to know if a received link preview was blacklisted.

### Solutions

Add a `isBlacklisted` property on the link preview metadata object.