### PR TITLE
Support SoundCloud mobile og:type values

### DIFF
--- a/WireLinkPreview/LinkAttachmentTypes.swift
+++ b/WireLinkPreview/LinkAttachmentTypes.swift
@@ -110,9 +110,9 @@ extension LinkAttachment {
     convenience init?(openGraphData: OpenGraphData, detectedType: LinkAttachmentType, originalRange: NSRange) {
         switch detectedType {
         case .soundCloudPlaylist:
-            guard openGraphData.type.hasPrefix("music.playlist") else { return nil }
+            guard openGraphData.type.hasPrefix("music.playlist") || openGraphData.type.hasPrefix("soundcloud:set") else { return nil }
         case .soundCloudTrack:
-            guard openGraphData.type.hasPrefix("music.song") else { return nil }
+            guard openGraphData.type.hasPrefix("music.song") || openGraphData.type.hasPrefix("soundcloud:sound") else { return nil }
         case .youTubeVideo:
             guard openGraphData.type.hasPrefix("video") else { return nil }
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

Links from `m.soundcloud.com` did not have a preview.

### Causes

SoundCloud returns a different `og:type` value on the mobile domain.

### Solutions

Check for these types.