### PR TITLE
[Fix] Twitter links are not producing link previews 

### DIFF
--- a/WireLinkPreview/PreviewDownloader.swift
+++ b/WireLinkPreview/PreviewDownloader.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 
-private let userAgent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
+private let userAgent = "WireLinkPreview"
 
 protocol PreviewDownloaderType {
     func requestOpenGraphData(fromURL url: URL, completion: @escaping (OpenGraphData?) -> Void)

--- a/WireLinkPreviewTests/PreviewDownloaderTests.swift
+++ b/WireLinkPreviewTests/PreviewDownloaderTests.swift
@@ -213,7 +213,7 @@ class PreviewDownloaderTests: XCTestCase {
         sut.requestOpenGraphData(fromURL: url, completion: completion)
         
         // then
-        let expected = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36"
+        let expected = "WireLinkPreview"
         XCTAssertEqual(mockSession.dataTaskWithURLCallCount, 1)
         let request = mockSession.dataTaskWithURLParameters.first
         let agent = request?.allHTTPHeaderFields?["User-Agent"]


### PR DESCRIPTION
## What's new in this PR?

### Issues

Twitter links like https://twitter.com/jaredsinclair/status/1233048163247960065 are not producing links previews anymore.

### Causes

Twitter has stopped serving open graph metadata tags for desktop browsers.

### Solutions

Change our user agent to not match a desktop browser. We also don't want to use the standard user agent since that would serve us mobile versions of websites.