### PR TITLE
[Fix] Change user agent to fix twitter link previews

### DIFF
--- a/WireLinkPreview/PreviewDownloader.swift
+++ b/WireLinkPreview/PreviewDownloader.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 
-private let userAgent = "WireLinkPreview"
+private let userAgent = "Wire LinkPreview Bot"
 
 protocol PreviewDownloaderType {
     func requestOpenGraphData(fromURL url: URL, completion: @escaping (OpenGraphData?) -> Void)


### PR DESCRIPTION
## What's new in this PR?

### Issues

Twitter link previews aren't working

### Causes

The response when fetching a twitter link is not including OG tags anymore which we use to create the link preview.

As mentioned in https://github.com/wireapp/wire-ios-link-preview/issues/59 twitter has changed their rules for when they include OG tags, to only include them if the user agent includes the word "bot".

### Solution

Change the user agent string to include the word "bot".
