### PR TITLE
[FIx] Change user agent to fix twitter link previews

### DIFF
--- a/WireLinkPreview/PreviewDownloader.swift
+++ b/WireLinkPreview/PreviewDownloader.swift
@@ -19,7 +19,7 @@
 
 import Foundation
 
-private let userAgent = "WireLinkPreview"
+private let userAgent = "Wire LinkPreview Bot"
 
 protocol PreviewDownloaderType {
     func requestOpenGraphData(fromURL url: URL, completion: @escaping (OpenGraphData?) -> Void)

--- a/WireLinkPreviewTests/IntegrationTests.swift
+++ b/WireLinkPreviewTests/IntegrationTests.swift
@@ -21,13 +21,13 @@ import XCTest
 
 class IntegrationTests: XCTestCase {
 
-    func disabled_testThatItParsesSampleDataTwitter() {
+    func testThatItParsesSampleDataTwitter() {
         let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "article", siteNameString: "Twitter", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.twitterData()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
     
-    func disabled_testThatItParsesSampleDataTwitterWithImages() {
+    func testThatItParsesSampleDataTwitterWithImages() {
         let expectation = OpenGraphDataExpectation(numberOfImages: 4, type: "article", siteNameString: "Twitter", userGeneratedImage: true, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.twitterDataWithImages()
         assertThatItCanParseSampleData(mockData, expected: expectation)

--- a/WireLinkPreviewTests/PreviewDownloaderTests.swift
+++ b/WireLinkPreviewTests/PreviewDownloaderTests.swift
@@ -213,7 +213,7 @@ class PreviewDownloaderTests: XCTestCase {
         sut.requestOpenGraphData(fromURL: url, completion: completion)
         
         // then
-        let expected = "WireLinkPreview"
+        let expected = "Wire LinkPreview Bot"
         XCTAssertEqual(mockSession.dataTaskWithURLCallCount, 1)
         let request = mockSession.dataTaskWithURLParameters.first
         let agent = request?.allHTTPHeaderFields?["User-Agent"]


### PR DESCRIPTION
## What's new in this PR?

### Issues

Twitter link previews aren't working

### Causes

The response when fetching a twitter link is not including OG tags anymore which we use to create the link preview.

As mentioned in https://github.com/wireapp/wire-ios-link-preview/issues/59 twitter has changed their rules for when they include OG tags, to only include them if the user agent includes the word "bot".

### Solution

Change the user agent string to include the word "bot".
