### PR TITLE
[Fix] Link preview not working for Youtube links 

### DIFF
--- a/WireLinkPreview/MetaStreamContainer.swift
+++ b/WireLinkPreview/MetaStreamContainer.swift
@@ -56,7 +56,7 @@ final class MetaStreamContainer {
 
     private func updateReachedEndOfHead(withData data: Data) {
         guard let string = parseString(from: data)?.lowercased() else { return }
-        if string.contains(OpenGraphXMLNode.headEnd.rawValue) || string.count > MetaStreamContainer.fetchLimit {
+        if string.contains(OpenGraphXMLNode.headEnd.rawValue)/* || string.count > MetaStreamContainer.fetchLimit*/ {
             reachedEndOfHead = true
         }
     }

--- a/WireLinkPreview/MetaStreamContainer.swift
+++ b/WireLinkPreview/MetaStreamContainer.swift
@@ -21,9 +21,7 @@ import Foundation
 
 
 final class MetaStreamContainer {
-    
-    static let fetchLimit = 50_000 // maximum number of characters to take if we can't find </head>
-    
+        
     var bytes = Data()
     
     var stringContent: String? {
@@ -56,7 +54,7 @@ final class MetaStreamContainer {
 
     private func updateReachedEndOfHead(withData data: Data) {
         guard let string = parseString(from: data)?.lowercased() else { return }
-        if string.contains(OpenGraphXMLNode.headEnd.rawValue)/* || string.count > MetaStreamContainer.fetchLimit*/ {
+        if string.contains(OpenGraphXMLNode.headEnd.rawValue) {
             reachedEndOfHead = true
         }
     }

--- a/WireLinkPreview/PreviewDownloader.swift
+++ b/WireLinkPreview/PreviewDownloader.swift
@@ -106,7 +106,7 @@ final class PreviewDownloader: NSObject, URLSessionDataDelegate, PreviewDownload
             guard container.reachedEndOfHead else { return }
             cancel(task: task)
         default:
-            return
+            break
         }
 //        if task.state == .running {
 //            guard container.reachedEndOfHead else { return }

--- a/WireLinkPreview/PreviewDownloader.swift
+++ b/WireLinkPreview/PreviewDownloader.swift
@@ -108,16 +108,6 @@ final class PreviewDownloader: NSObject, URLSessionDataDelegate, PreviewDownload
         default:
             break
         }
-//        if task.state == .running {
-//            guard container.reachedEndOfHead else { return }
-//            cancel(task: task)
-//        }
-        
-//        guard container.reachedEndOfHead,
-//            let url = task.originalRequest?.url,
-//            let completion = completionByURL[url] else { return }
-//
-//        cancel(task: task)
         
         parseMetaHeader(container, url: url) { [weak self] result in
             guard let `self` = self else { return }

--- a/WireLinkPreview/PreviewDownloader.swift
+++ b/WireLinkPreview/PreviewDownloader.swift
@@ -97,12 +97,17 @@ final class PreviewDownloader: NSObject, URLSessionDataDelegate, PreviewDownload
         let container = containerByTaskID[identifier] ?? MetaStreamContainer()
         container.addData(data)
         containerByTaskID[identifier] = container
-
-        guard container.reachedEndOfHead,
-            let url = task.originalRequest?.url,
+        
+        guard let url = task.originalRequest?.url,
             let completion = completionByURL[url] else { return }
-
-        cancel(task: task)
+        
+        switch task.state {
+        case .running:
+            guard container.reachedEndOfHead else { return }
+            cancel(task: task)
+        default:
+            break
+        }
         
         parseMetaHeader(container, url: url) { [weak self] result in
             guard let `self` = self else { return }

--- a/WireLinkPreview/PreviewDownloader.swift
+++ b/WireLinkPreview/PreviewDownloader.swift
@@ -108,12 +108,16 @@ final class PreviewDownloader: NSObject, URLSessionDataDelegate, PreviewDownload
 //        default:
 //            break
 //        }
+        if task.state == .running {
+            guard container.reachedEndOfHead else { return }
+            cancel(task: task)
+        }
         
-        guard container.reachedEndOfHead,
-            let url = task.originalRequest?.url,
-            let completion = completionByURL[url] else { return }
-        
-        cancel(task: task)
+//        guard container.reachedEndOfHead,
+//            let url = task.originalRequest?.url,
+//            let completion = completionByURL[url] else { return }
+//
+//        cancel(task: task)
         
         parseMetaHeader(container, url: url) { [weak self] result in
             guard let `self` = self else { return }

--- a/WireLinkPreview/PreviewDownloader.swift
+++ b/WireLinkPreview/PreviewDownloader.swift
@@ -98,20 +98,20 @@ final class PreviewDownloader: NSObject, URLSessionDataDelegate, PreviewDownload
         container.addData(data)
         containerByTaskID[identifier] = container
         
-//        guard let url = task.originalRequest?.url,
-//            let completion = completionByURL[url] else { return }
-//
-//        switch task.state {
-//        case .running:
-//            guard container.reachedEndOfHead else { return }
-//            cancel(task: task)
-//        default:
-//            break
-//        }
-        if task.state == .running {
+        guard let url = task.originalRequest?.url,
+            let completion = completionByURL[url] else { return }
+
+        switch task.state {
+        case .running:
             guard container.reachedEndOfHead else { return }
             cancel(task: task)
+        default:
+            return
         }
+//        if task.state == .running {
+//            guard container.reachedEndOfHead else { return }
+//            cancel(task: task)
+//        }
         
 //        guard container.reachedEndOfHead,
 //            let url = task.originalRequest?.url,

--- a/WireLinkPreview/PreviewDownloader.swift
+++ b/WireLinkPreview/PreviewDownloader.swift
@@ -98,16 +98,22 @@ final class PreviewDownloader: NSObject, URLSessionDataDelegate, PreviewDownload
         container.addData(data)
         containerByTaskID[identifier] = container
         
-        guard let url = task.originalRequest?.url,
+//        guard let url = task.originalRequest?.url,
+//            let completion = completionByURL[url] else { return }
+//
+//        switch task.state {
+//        case .running:
+//            guard container.reachedEndOfHead else { return }
+//            cancel(task: task)
+//        default:
+//            break
+//        }
+        
+        guard container.reachedEndOfHead,
+            let url = task.originalRequest?.url,
             let completion = completionByURL[url] else { return }
         
-        switch task.state {
-        case .running:
-            guard container.reachedEndOfHead else { return }
-            cancel(task: task)
-        default:
-            break
-        }
+        cancel(task: task)
         
         parseMetaHeader(container, url: url) { [weak self] result in
             guard let `self` = self else { return }

--- a/WireLinkPreview/URLSessionProtocols.swift
+++ b/WireLinkPreview/URLSessionProtocols.swift
@@ -33,6 +33,7 @@ protocol URLSessionDataTaskType {
     
     var originalRequest: URLRequest? { get }
     var taskIdentifier: Int { get }
+    var state: URLSessionTask.State { get }
 }
 
 extension URLSessionTask: URLSessionDataTaskType {}

--- a/WireLinkPreviewTests/IntegrationTests.swift
+++ b/WireLinkPreviewTests/IntegrationTests.swift
@@ -64,7 +64,7 @@ class IntegrationTests: XCTestCase {
     }
     
     func testThatItParsesSampleDataVimeo() {
-        let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "video", siteNameString: "Vimeo", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
+        let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "video.other", siteNameString: "Vimeo", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.vimeoData()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }

--- a/WireLinkPreviewTests/MetaStreamContainerTests.swift
+++ b/WireLinkPreviewTests/MetaStreamContainerTests.swift
@@ -159,13 +159,6 @@ class MetaStreamContainerTests: XCTestCase {
         let html = "<!DOCTYPE html><html lang=\"en\">\n\(head)"
         assertThatItExtractsTheCorrectHead(html, expectedHead: head, encoding: .ascii)
     }
-        
-    func testThatItExtractsTheHead_toEndOfString_whenItDoesNotHaveEndTag() {
-        let junk = Array(repeating: "JUNK", count: MetaStreamContainer.fetchLimit).joined(separator: "-")
-        let head = "<head data-network=\"123\">\nheader\n" + junk
-        let html = "<!DOCTYPE html><html lang=\"en\">\n\(head)"
-        assertThatItExtractsTheCorrectHead(html, expectedHead: head, encoding: .ascii)
-    }
     
     // MARK: - Helper
     

--- a/WireLinkPreviewTests/URLMocks.swift
+++ b/WireLinkPreviewTests/URLMocks.swift
@@ -24,6 +24,7 @@ class MockURLSessionDataTask: URLSessionDataTaskType {
     var resumeCallCount = 0
     var cancelCallCount = 0
     var mockOriginalRequest: URLRequest? = nil
+    var state: URLSessionTask.State = .completed
     
     var originalRequest: URLRequest? {
         return mockOriginalRequest
@@ -31,10 +32,12 @@ class MockURLSessionDataTask: URLSessionDataTaskType {
     
     func resume() {
         resumeCallCount += 1
+        state = .running
     }
     
     func cancel() {
         cancelCallCount += 1
+        state = .canceling
     }
 }
 


### PR DESCRIPTION
## What's new in this PR?
https://wearezeta.atlassian.net/browse/SQSERVICES-67

### Issues
User doesn't see a link previews for Youtube links. 

### Causes
There is a limit on the amount of data we want to fetch. 
Some websites in the wild don’t have the closing `</head> tag`, so this was a way to reduce the amount of data that needs to be downloaded. We check if there is a closing ` </head> tag `or the download data is less than the set limit.
As a result, we was canceling the task of fetching data without getting all necessary data (all metadata)

### Solutions
Solution is to remove the current fetch limit. This was done because we assume that there will be more cases when the amount of data is bigger than we expected (and it's not easy to predict the average amount of data) than websites without closing `</head> tag`.
