### PR TITLE
fix: SwiftLint warnings for multiple rules & remove a bunch of them from the disabled rules list

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,29 +2,9 @@ disabled_rules:
     - function_body_length
     - type_body_length
     - file_length
-    - generic_type_name
-    - force_cast
     - force_try
-    - type_name
     - todo
-    - large_tuple
-    - unused_setter_value
-    - notification_center_detachment
-    - discarded_notification_center_observer
-    - cyclomatic_complexity
-    - closure_parameter_position
-    - statement_position
-    - weak_delegate
     - inclusive_language
-    - class_delegate_protocol
-    - legacy_cggeometry_functions
-    - legacy_constructor
-    - legacy_hashing
-    - multiple_closures_with_trailing_closure
-    - nesting
-    - function_parameter_count
-    - compiler_protocol_init
-    - reduce_boolean
 
 included:
     - WireLinkPreview

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -23,7 +23,6 @@ disabled_rules:
     - multiple_closures_with_trailing_closure
     - nesting
     - function_parameter_count
-    - xctfail_message
     - compiler_protocol_init
     - reduce_boolean
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,7 +5,6 @@ disabled_rules:
     - generic_type_name
     - force_cast
     - force_try
-    - identifier_name
     - type_name
     - todo
     - large_tuple

--- a/WireLinkPreview/LinkAttachmentDetector.swift
+++ b/WireLinkPreview/LinkAttachmentDetector.swift
@@ -54,7 +54,7 @@ public protocol LinkAttachmentDetectorType {
 
 public final class LinkAttachmentDetector: NSObject, LinkAttachmentDetectorType {
 
-    private let linkDetector : NSDataDetector? = NSDataDetector.linkDetector
+    private let linkDetector: NSDataDetector? = NSDataDetector.linkDetector
     private let previewDownloader: PreviewDownloaderType
     private let workerQueue: OperationQueue
 

--- a/WireLinkPreview/LinkAttachmentTypes.swift
+++ b/WireLinkPreview/LinkAttachmentTypes.swift
@@ -37,7 +37,7 @@ public enum LinkAttachmentType: Int {
 
 @objc(ZMLinkAttachment)
 public class LinkAttachment: NSObject, NSSecureCoding {
-    
+
     public static var supportsSecureCoding = true
 
     /// The type of the attached media.

--- a/WireLinkPreview/LinkPreviewDetector.swift
+++ b/WireLinkPreview/LinkPreviewDetector.swift
@@ -16,25 +16,24 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 import WireUtilities
 
 public protocol LinkPreviewDetectorType {
-    
+
     func downloadLinkPreviews(inText text: String, excluding: [NSRange], completion: @escaping ([LinkMetadata]) -> Void)
-    
+
 }
 
-public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
-    
-    private let linkDetector : NSDataDetector? = NSDataDetector.linkDetector
+public final class LinkPreviewDetector: NSObject, LinkPreviewDetectorType {
+
+    private let linkDetector: NSDataDetector? = NSDataDetector.linkDetector
     private let previewDownloader: PreviewDownloaderType
     private let imageDownloader: ImageDownloaderType
     private let workerQueue: OperationQueue
-    
+
     public typealias DetectCompletion = ([LinkMetadata]) -> Void
-    
+
     public convenience override init() {
         let workerQueue = OperationQueue()
         self.init(
@@ -43,7 +42,7 @@ public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
             workerQueue: workerQueue
         )
     }
-    
+
     init(previewDownloader: PreviewDownloaderType, imageDownloader: ImageDownloaderType, workerQueue: OperationQueue) {
         self.workerQueue = workerQueue
         self.previewDownloader = previewDownloader
@@ -82,5 +81,5 @@ public final class LinkPreviewDetector : NSObject, LinkPreviewDetectorType {
     deinit {
         previewDownloader.tearDown()
     }
-    
+
 }

--- a/WireLinkPreview/LinkPreviewTypes.swift
+++ b/WireLinkPreview/LinkPreviewTypes.swift
@@ -16,21 +16,19 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 
+@objcMembers open class LinkMetadata: NSObject {
 
-@objcMembers open class LinkMetadata : NSObject {
-    
     public let originalURLString: String
     public let permanentURL: URL?
     public let resolvedURL: URL?
     public let characterOffsetInText: Int
     open var imageURLs = [URL]()
     open var imageData = [Data]()
-    
+
     public typealias DownloadCompletion = (_ successful: Bool) -> Void
-    
+
     public init(originalURLString: String, permanentURLString: String, resolvedURLString: String, offset: Int) {
         self.originalURLString = originalURLString
         permanentURL = URL(string: permanentURLString)
@@ -39,7 +37,7 @@ import Foundation
         super.init()
     }
 
-    @objc public var isBlacklisted: Bool {
+    public var isBlacklisted: Bool {
         if let permanentURL = permanentURL {
             return PreviewBlacklist.isBlacklisted(permanentURL)
         } else if let resolvedURL = resolvedURL {
@@ -48,7 +46,7 @@ import Foundation
             return false
         }
     }
-    
+
     func requestAssets(withImageDownloader downloader: ImageDownloaderType, completion: @escaping DownloadCompletion) {
         guard let imageURL = imageURLs.first else { return completion(false) }
         downloader.downloadImage(fromURL: imageURL) { [weak self] imageData in
@@ -60,26 +58,25 @@ import Foundation
 
 }
 
-
-@objcMembers public class ArticleMetadata : LinkMetadata {
-    public var title : String?
-    public var summary : String?
+@objcMembers public class ArticleMetadata: LinkMetadata {
+    public var title: String?
+    public var summary: String?
 }
 
-@objcMembers public class FoursquareLocationMetadata : LinkMetadata {
-    public var title : String?
-    public var subtitle : String?
+@objcMembers public class FoursquareLocationMetadata: LinkMetadata {
+    public var title: String?
+    public var subtitle: String?
     public var latitude: Float?
     public var longitude: Float?
 }
 
-@objcMembers public class InstagramPictureMetadata : LinkMetadata {
-    public var title : String?
-    public var subtitle : String?
+@objcMembers public class InstagramPictureMetadata: LinkMetadata {
+    public var title: String?
+    public var subtitle: String?
 }
 
-@objcMembers public class TwitterStatusMetadata : LinkMetadata {
-    public var message : String?
-    public var username : String?
-    public var author : String?
+@objcMembers public class TwitterStatusMetadata: LinkMetadata {
+    public var message: String?
+    public var username: String?
+    public var author: String?
 }

--- a/WireLinkPreview/MetaStreamContainer.swift
+++ b/WireLinkPreview/MetaStreamContainer.swift
@@ -16,24 +16,22 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 
-
 final class MetaStreamContainer {
-        
+
     var bytes = Data()
-    
+
     var stringContent: String? {
         return parseString(from: bytes)
     }
-    
+
     var head: String? {
         guard let content = stringContent else { return nil }
         var startBound = content.range(of: OpenGraphXMLNode.headStart.rawValue)?.lowerBound ??
                            content.range(of: OpenGraphXMLNode.headStartNoAttributes.rawValue)?.lowerBound ??
                            content.startIndex
-        
+
         let upperBound = content.range(of: OpenGraphXMLNode.headEnd.rawValue)?.upperBound ?? content.endIndex
 
         if startBound >= upperBound {
@@ -43,9 +41,9 @@ final class MetaStreamContainer {
         let result = content[startBound..<upperBound]
         return String(result)
     }
-    
+
     var reachedEndOfHead = false
-    
+
     @discardableResult func addData(_ data: Data) -> Data {
         updateReachedEndOfHead(withData: data)
         bytes.append(data)

--- a/WireLinkPreview/NSDataDetector+LinkAttachments.swift
+++ b/WireLinkPreview/NSDataDetector+LinkAttachments.swift
@@ -75,5 +75,5 @@ extension NSDataDetector {
 
         return nil
     }
-    
+
 }

--- a/WireLinkPreview/OpenGraphData.swift
+++ b/WireLinkPreview/OpenGraphData.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 
 public struct OpenGraphData {
@@ -30,9 +29,9 @@ public struct OpenGraphData {
     let siteNameString: String?
     let content: String?
     let userGeneratedImage: Bool
-    
+
     var foursquareMetaData: FoursquareMetaData?
-    
+
     init(title: String, type: String?, url: String, resolvedURL: String, imageUrls: [String], siteName: String? = nil, description: String? = nil, userGeneratedImage: Bool = false) {
         self.title = title
         self.type = type ?? OpenGraphTypeType.website.rawValue
@@ -57,12 +56,12 @@ extension OpenGraphData: CustomStringConvertible {
 public struct FoursquareMetaData {
     let latitude: Float
     let longitude: Float
-    
+
     init(latitude: Float, longitude: Float) {
         self.latitude = latitude
         self.longitude = longitude
     }
-    
+
     init?(propertyMapping mapping: OpenGraphData.PropertyMapping) {
         guard let latitude = mapping[.latitudeFSQ].flatMap(Float.init), let longitude = mapping[.longitudeFSQ].flatMap(Float.init) else { return nil }
         self.init(latitude: latitude, longitude: longitude)
@@ -70,13 +69,13 @@ public struct FoursquareMetaData {
 }
 
 extension OpenGraphData {
-    
+
     typealias PropertyMapping = [OpenGraphPropertyType: String]
-    
+
     init?(propertyMapping mapping: PropertyMapping, resolvedURL: URL, images: [String]) {
         guard let title = mapping[.title],
             let url = mapping[.url] else { return nil }
-     
+
         self.init(
             title: title,
             type: mapping[.type],
@@ -87,10 +86,10 @@ extension OpenGraphData {
             description: mapping[.description],
             userGeneratedImage: mapping[.userGeneratedImage] == "true"
         )
-        
+
         foursquareMetaData = FoursquareMetaData(propertyMapping: mapping)
     }
-    
+
 }
 
 extension OpenGraphData: Equatable {}
@@ -122,7 +121,7 @@ extension ArticleMetadata {
 extension FoursquareLocationMetadata {
     public convenience init?(openGraphData: OpenGraphData, originalURLString: String, offset: Int) {
         guard openGraphData.type  == OpenGraphTypeType.foursquare.rawValue && openGraphData.siteName == .foursquare else { return nil }
-        
+
         self.init(originalURLString: originalURLString, permanentURLString: openGraphData.url, resolvedURLString: openGraphData.resolvedURL, offset: offset)
         title = openGraphData.title
         subtitle = openGraphData.content
@@ -149,27 +148,27 @@ extension TwitterStatusMetadata {
     public convenience init?(openGraphData: OpenGraphData, originalURLString: String, offset: Int) {
         guard openGraphData.type == OpenGraphTypeType.article.rawValue && openGraphData.siteName == .twitter else { return nil }
         self.init(originalURLString: originalURLString, permanentURLString: openGraphData.url, resolvedURLString: openGraphData.resolvedURL, offset: offset)
-        
+
         message = tweetContentFromOpenGraphData(openGraphData)
         author = tweetAuthorFromOpenGraphData(openGraphData)
         imageURLs = openGraphData.userGeneratedImage ? openGraphData.imageUrls.compactMap(URL.init) : []
     }
-    
+
     private func tweetContentFromOpenGraphData(_ data: OpenGraphData) -> String? {
         var tweet = data.content
         tweet = tweet?.replacingOccurrences(of: "“", with: "", options: .anchored, range: nil)
         tweet = tweet?.replacingOccurrences(of: "”", with: "", options: [.anchored, .backwards], range: nil)
         return tweet
     }
-    
+
     private func tweetAuthorFromOpenGraphData(_ data: OpenGraphData) -> String {
         let authorSuffix = " on Twitter"
         return data.title.replacingOccurrences(of: authorSuffix, with: "", options: [.anchored, .backwards], range: nil)
     }
 }
 
-extension OpenGraphData  {
-    
+extension OpenGraphData {
+
     func linkPreview(_ originalURLString: String, offset: Int) -> LinkMetadata {
         return TwitterStatusMetadata(openGraphData: self, originalURLString: originalURLString, offset: offset) ??
             ArticleMetadata(openGraphData: self, originalURLString: originalURLString, offset: offset)

--- a/WireLinkPreview/OpenGraphData.swift
+++ b/WireLinkPreview/OpenGraphData.swift
@@ -94,7 +94,7 @@ extension OpenGraphData {
 
 extension OpenGraphData: Equatable {}
 
-public func ==(lhs: OpenGraphData, rhs: OpenGraphData) -> Bool {
+public func == (lhs: OpenGraphData, rhs: OpenGraphData) -> Bool {
     return lhs.title == rhs.title && lhs.type == rhs.type &&
         lhs.url == rhs.url && lhs.imageUrls == rhs.imageUrls &&
         lhs.siteName == rhs.siteName && lhs.content == rhs.content &&
@@ -104,7 +104,7 @@ public func ==(lhs: OpenGraphData, rhs: OpenGraphData) -> Bool {
 
 extension FoursquareMetaData: Equatable {}
 
-public func ==(lhs: FoursquareMetaData, rhs: FoursquareMetaData) -> Bool {
+public func == (lhs: FoursquareMetaData, rhs: FoursquareMetaData) -> Bool {
     return lhs.latitude == rhs.latitude && lhs.longitude == rhs.longitude
 }
 

--- a/WireLinkPreview/OpenGraphDataTypes.swift
+++ b/WireLinkPreview/OpenGraphDataTypes.swift
@@ -45,11 +45,11 @@ enum OpenGraphPropertyType: String {
 
 enum OpenGraphSiteName: String {
     case other
-    case twitter = "twitter"
-    case vimeo = "vimeo"
-    case youtube = "youtube"
-    case instagram = "instagram"
-    case foursquare = "foursquare"
+    case twitter
+    case vimeo
+    case youtube
+    case instagram
+    case foursquare
 
     init?(string: String) {
         self.init(rawValue: string.lowercased())

--- a/WireLinkPreview/OpenGraphDataTypes.swift
+++ b/WireLinkPreview/OpenGraphDataTypes.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 
 enum OpenGraphAttribute {
@@ -38,7 +37,7 @@ enum OpenGraphPropertyType: String {
     case description = "og:description"
     case siteName = "og:site_name"
     case userGeneratedImage = "og:image:user_generated"
-    
+
     // MARK: Foursquare
     case latitudeFSQ = "playfoursquare:location:latitude"
     case longitudeFSQ = "playfoursquare:location:longitude"
@@ -51,7 +50,7 @@ enum OpenGraphSiteName: String {
     case youtube = "youtube"
     case instagram = "instagram"
     case foursquare = "foursquare"
-    
+
     init?(string: String) {
         self.init(rawValue: string.lowercased())
     }

--- a/WireLinkPreview/OpenGraphScanner.swift
+++ b/WireLinkPreview/OpenGraphScanner.swift
@@ -19,9 +19,9 @@
 import Foundation
 
 final class OpenGraphScanner: NSObject {
-    
+
     typealias ParserCompletion = (OpenGraphData?) -> Void
-    
+
     let xmlString: String
     var contentsByProperty = [OpenGraphPropertyType: String]()
     var images = [String]()
@@ -35,7 +35,7 @@ final class OpenGraphScanner: NSObject {
         originalURL = url
         super.init()
     }
-    
+
     func parse() {
         // 1. Parse the document
         guard let document = HTMLDocument(xmlString: xmlString) else { return completion(nil) }
@@ -74,8 +74,7 @@ final class OpenGraphScanner: NSObject {
     private func parseOpenGraphMetadata(_ element: HTMLElement) {
         if let rawProperty = element[attribute: OpenGraphAttribute.property]?.stringValue(removingEntities: false),
             let property = OpenGraphPropertyType(rawValue: rawProperty),
-            let content = element[attribute: OpenGraphAttribute.content]?.stringValue(removingEntities: true)
-        {
+            let content = element[attribute: OpenGraphAttribute.content]?.stringValue(removingEntities: true) {
             addProperty(property, value: content)
         }
     }

--- a/WireLinkPreview/PreviewBlacklist.swift
+++ b/WireLinkPreview/PreviewBlacklist.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 
 enum PreviewBlacklist {
@@ -29,7 +28,7 @@ enum PreviewBlacklist {
         "spotify",
         "giphy"
     ]
-    
+
     static func isBlacklisted(_ url: URL) -> Bool {
         return blacklistedHosts.contains { blacklisted in
             url.absoluteString.lowercased().contains(blacklisted)

--- a/WireLinkPreview/URLSessionProtocols.swift
+++ b/WireLinkPreview/URLSessionProtocols.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 
 typealias DataTaskCompletion = (Data?, URLResponse?, Error?) -> Void
@@ -30,7 +29,7 @@ protocol URLSessionType {
 protocol URLSessionDataTaskType {
     func resume()
     func cancel()
-    
+
     var originalRequest: URLRequest? { get }
     var taskIdentifier: Int { get }
     var state: URLSessionTask.State { get }
@@ -42,7 +41,7 @@ extension URLSession: URLSessionType {
     func dataTask(with request: URLRequest) -> URLSessionDataTaskType {
         return (dataTask(with: request) as URLSessionDataTask) as URLSessionDataTaskType
     }
-    
+
     func dataTaskWithURL(_ url: URL, completionHandler: @escaping DataTaskCompletion) -> URLSessionDataTaskType {
         return (dataTask(with: url, completionHandler: completionHandler) as URLSessionDataTask) as URLSessionDataTaskType
     }

--- a/WireLinkPreviewTests/DownloaderMocks.swift
+++ b/WireLinkPreviewTests/DownloaderMocks.swift
@@ -16,18 +16,17 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 @testable import WireLinkPreview
 
 class MockPreviewDownloader: PreviewDownloaderType {
-    
+
     typealias Completion = (OpenGraphData?) -> Void
-    
-    var mockOpenGraphData: OpenGraphData? = nil
+
+    var mockOpenGraphData: OpenGraphData?
     var requestOpenGraphDataCallCount = 0
     var requestOpenGraphDataURLs = [URL]()
     var requestOpenGraphDataCompletions = [Completion]()
-    
+
     func requestOpenGraphData(fromURL url: URL, completion: @escaping Completion) {
         requestOpenGraphDataCallCount += 1
         requestOpenGraphDataURLs.append(url)
@@ -42,26 +41,26 @@ class MockPreviewDownloader: PreviewDownloaderType {
 }
 
 class MockImageDownloader: ImageDownloaderType {
-    
+
     typealias ImageCompletion = (Data?) -> Void
-    var mockImageData: Data? = nil
+    var mockImageData: Data?
     var downloadImageURLs = [URL]()
     var downloadImageCallCount = 0
     var downloadImageCompletion = [ImageCompletion]()
-    
-    typealias ImagesCompletion = ([URL : Data]) -> Void
+
+    typealias ImagesCompletion = ([URL: Data]) -> Void
     var mockImageDataByUrl = [URL: Data]()
     var downloadImagesCallCount = 0
     var downloadImagesURLs = [URL]()
     var downloadImagesCompletion = [ImagesCompletion]()
-    
+
     func downloadImage(fromURL url: URL, completion: @escaping ImageCompletion) {
         downloadImageCallCount += 1
         downloadImageURLs.append(url)
         downloadImageCompletion.append(completion)
         completion(mockImageData)
     }
-    
+
     func downloadImages(fromURLs urls: [URL], completion: @escaping ImagesCompletion) {
         downloadImagesCallCount += 1
         downloadImageURLs.append(contentsOf: urls)

--- a/WireLinkPreviewTests/IntegrationTests.swift
+++ b/WireLinkPreviewTests/IntegrationTests.swift
@@ -26,38 +26,38 @@ final class IntegrationTests: XCTestCase {
         let mockData = OpenGraphMockDataProvider.twitterData()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
-    
+
     func testThatItParsesSampleDataTwitterWithImages() {
         let expectation = OpenGraphDataExpectation(numberOfImages: 4, type: "article", siteNameString: "Twitter", userGeneratedImage: true, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.twitterDataWithImages()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
-    
+
     func testThatItParsesSampleDataTheVerge() {
         let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "article", siteNameString: "The Verge", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.vergeData()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
-    
+
     func testThatItParsesSampleDataWashington() {
         let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "article", siteNameString: "Washington Post", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.washingtonPostData()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
-    
+
     func disabled_testThatItParsesSampleDataYouTube() {
         let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "video.other", siteNameString: "YouTube", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.youtubeData()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
-    
+
     func testThatItParsesSampleDataGuardian() {
         let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "article", siteNameString: "the Guardian", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.guardianData()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
-    
-    ///TODO: check why on CI got result:
+
+    /// TODO: check why on CI got result:
     /// XCTAssertEqual failed: ("false") is not equal to ("true") - Should have description
     /// XCTAssertEqual failed: ("Optional("website")") is not equal to ("Optional("instapp:photo")") - Type should be instapp:photo, found:website
     /// XCTAssertEqual failed: ("nil") is not equal to ("Optional("Instagram")") - Site name should be Instagram, found: nil
@@ -66,32 +66,32 @@ final class IntegrationTests: XCTestCase {
         let mockData = OpenGraphMockDataProvider.instagramData()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
-    
+
     func testThatItParsesSampleDataVimeo() {
         let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "video.other", siteNameString: "Vimeo", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.vimeoData()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
-    
+
     func testThatItParsesSampleDataFoursquare() {
         let expectation = OpenGraphDataExpectation(numberOfImages: 4, type: "playfoursquare:venue", siteNameString: "Foursquare", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: true)
         let mockData = OpenGraphMockDataProvider.foursquareData()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
-    
+
     func testThatItParsesSampleDataMedium() {
         let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "article", siteNameString: "Medium", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.mediumData()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
 
-    //TODO: failed with Xcode 13.1
+    // TODO: failed with Xcode 13.1
     func disable_testThatItParsesSampleDataWire() {
         let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "website", siteNameString: nil, userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.wireData()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
-    
+
     func testThatItParsesSampleDataPolygon() {
         let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "article", siteNameString: "Polygon", userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.polygonData()
@@ -99,7 +99,7 @@ final class IntegrationTests: XCTestCase {
     }
 
     let uft16ExpectedString = "Apple\u{A0}Music"
-    
+
     func disabled_testThatItParsesSampleDataiTunes() {
         let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "music.album", siteNameString: uft16ExpectedString, userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.iTunesData()
@@ -111,7 +111,7 @@ final class IntegrationTests: XCTestCase {
         let mockData = OpenGraphMockDataProvider.iTunesDataWithoutTitle()
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
-    
+
     func testThatItParsesSampleDataYahooSports() {
         let expectation = OpenGraphDataExpectation(numberOfImages: 1, type: "article", siteNameString: nil, userGeneratedImage: false, hasDescription: true, hasFoursquareMetaData: false)
         let mockData = OpenGraphMockDataProvider.yahooSports()
@@ -130,7 +130,7 @@ final class IntegrationTests: XCTestCase {
         assertThatItCanParseSampleData(mockData, expected: expectation)
     }
 
-    ///TODO: check why CI got `XCTAssertNil failed: "<OpenGraphData> nil: https://instagram.com/404:`
+    /// TODO: check why CI got `XCTAssertNil failed: "<OpenGraphData> nil: https://instagram.com/404:`
     func testThatItDoesNotParse404Links() {
         let mockSite = OpenGraphMockData(head: "", expected: nil, urlString: "https://instagram.com/404", urlVersion: nil)
         assertThatItCanParseSampleData(mockSite, expected: nil)
@@ -144,7 +144,7 @@ final class IntegrationTests: XCTestCase {
         let hasDescription: Bool
         let hasFoursquareMetaData: Bool
     }
-    
+
     private func assertThatItCanParseSampleData(_ mockData: OpenGraphMockData,
                                         expected: OpenGraphDataExpectation?,
                                         line: UInt = #line) {
@@ -180,15 +180,15 @@ final class IntegrationTests: XCTestCase {
         guard let data = result else {
             return XCTFail("Could not extract open graph data from \(mockData.urlString)", line: line)
         }
-        
+
         // then
         XCTAssertEqual(data.content != nil, expected.hasDescription, expected.hasDescription ? "Should have description" : "Should not have description", line: line)
         XCTAssertEqual(data.foursquareMetaData != nil, expected.hasFoursquareMetaData, expected.hasFoursquareMetaData ? "Should have Foursquare metadata" : "Should not have Foursquare metadata", line: line)
         XCTAssertEqual(data.type, expected.type, "Type should be \(expected.type ?? "nil"), found:\(data.type)", line: line)
-                
+
         XCTAssertEqual(data.siteNameString, expected.siteNameString, "Site name should be \(expected.siteNameString ?? "nil"), found: \(data.siteNameString ?? "nil")", line: line)
         XCTAssertEqual(data.userGeneratedImage, expected.userGeneratedImage, "User generated image should match", line: line)
-        XCTAssertTrue(data.imageUrls.count == expected.numberOfImages, "Should have \(expected.numberOfImages) images, found:\(data.imageUrls.count)",line: line)
+        XCTAssertTrue(data.imageUrls.count == expected.numberOfImages, "Should have \(expected.numberOfImages) images, found:\(data.imageUrls.count)", line: line)
     }
-    
+
 }

--- a/WireLinkPreviewTests/IntegrationTests.swift
+++ b/WireLinkPreviewTests/IntegrationTests.swift
@@ -146,8 +146,8 @@ final class IntegrationTests: XCTestCase {
     }
 
     private func assertThatItCanParseSampleData(_ mockData: OpenGraphMockData,
-                                        expected: OpenGraphDataExpectation?,
-                                        line: UInt = #line) {
+                                                expected: OpenGraphDataExpectation?,
+                                                line: UInt = #line) {
 
         // given
         let completionExpectation = expectation(description: "It should parse the data")

--- a/WireLinkPreviewTests/LinkAttachmentDetectorTests.swift
+++ b/WireLinkPreviewTests/LinkAttachmentDetectorTests.swift
@@ -181,5 +181,4 @@ class LinkAttachmentDetectorTests: XCTestCase {
         waitForExpectations(timeout: 0.2, handler: nil)
     }
 
-
 }

--- a/WireLinkPreviewTests/LinkAttachmentTypesTests.swift
+++ b/WireLinkPreviewTests/LinkAttachmentTypesTests.swift
@@ -40,10 +40,10 @@ class LinkAttachmentTypesTests: XCTestCase {
 
     func testThatItDecodesYouTubeFromOpenGraph() {
         // GIVEN
-        let og = OpenGraphData(title: "iPhone X - Reveal", type: "video.other", url: "https://www.youtube.com/watch?v=sRIQsy2PGyM", resolvedURL: "https://www.youtube.com/watch?v=sRIQsy2PGyM", imageUrls: ["https://i.ytimg.com/vi/sRIQsy2PGyM/maxresdefault.jpg"])
+        let openGraphData = OpenGraphData(title: "iPhone X - Reveal", type: "video.other", url: "https://www.youtube.com/watch?v=sRIQsy2PGyM", resolvedURL: "https://www.youtube.com/watch?v=sRIQsy2PGyM", imageUrls: ["https://i.ytimg.com/vi/sRIQsy2PGyM/maxresdefault.jpg"])
 
         // WHEN
-        let decodedAttachment = LinkAttachment(openGraphData: og, detectedType: .youTubeVideo, originalRange: NSRange(location: 10, length: 43))
+        let decodedAttachment = LinkAttachment(openGraphData: openGraphData, detectedType: .youTubeVideo, originalRange: NSRange(location: 10, length: 43))
 
         // THEN
         XCTAssertEqual(decodedAttachment?.type, .youTubeVideo)

--- a/WireLinkPreviewTests/LinkAttachmentTypesTests.swift
+++ b/WireLinkPreviewTests/LinkAttachmentTypesTests.swift
@@ -52,5 +52,5 @@ class LinkAttachmentTypesTests: XCTestCase {
         XCTAssertEqual(decodedAttachment?.thumbnails, [URL(string: "https://i.ytimg.com/vi/sRIQsy2PGyM/maxresdefault.jpg")!])
         XCTAssertEqual(decodedAttachment?.originalRange, NSRange(location: 10, length: 43))
     }
-    
+
 }

--- a/WireLinkPreviewTests/MetaStreamContainerTests.swift
+++ b/WireLinkPreviewTests/MetaStreamContainerTests.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import XCTest
 @testable import WireLinkPreview
 
@@ -44,15 +43,15 @@ class MetaStreamContainerTests: XCTestCase {
     func testThatItSets_reachedEndOfHead_WhenDataContainsHead_Lowercase() {
         assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</head>")
     }
-    
+
     func testThatItSets_reachedEndOfHead_WhenDataContainsHead_Capitalized() {
         assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</Head>")
     }
-    
+
     func testThatItSets_reachedEndOfHead_WhenDataContainsHead_Uppercase() {
         assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</HEAD>")
     }
-    
+
     func testThatItSets_reachedEndOfHead_WhenDataContainsHead_WithSpaces() {
         assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</head >", shouldUpdate: false)
     }
@@ -88,7 +87,7 @@ class MetaStreamContainerTests: XCTestCase {
     func testThatItSets_reachedEndOfHead_WhenDataContainsHead_WithSpaces_ASCII() {
         assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead("</head >", shouldUpdate: false, encoding: .ascii)
     }
-    
+
     func testThatItExtractsTheHead_whenAllInOneLine() {
         let head = "<head>header</head>"
         let html = "<!DOCTYPE html><html lang=\"en\">\(head)"
@@ -111,13 +110,13 @@ class MetaStreamContainerTests: XCTestCase {
         let html = body + head
         assertThatItExtractsTheCorrectHead(html, expectedHead: body)
     }
-    
+
     func testThatItExtractsTheHead_whenOneASeparateLine() {
         let head = "<head>\nheader\n</head>"
         let html = "<!DOCTYPE html><html lang=\"en\">\n\(head)"
         assertThatItExtractsTheCorrectHead(html, expectedHead: head)
     }
-    
+
     func testThatItExtractsTheHead_whenItHasAttributes() {
         let head = "<head data-network=\"123\">\nheader\n</head>"
         let html = "<!DOCTYPE html><html lang=\"en\">\n\(head)"
@@ -159,37 +158,37 @@ class MetaStreamContainerTests: XCTestCase {
         let html = "<!DOCTYPE html><html lang=\"en\">\n\(head)"
         assertThatItExtractsTheCorrectHead(html, expectedHead: head, encoding: .ascii)
     }
-    
+
     // MARK: - Helper
-    
+
     func assertThatItExtractsTheCorrectHead(_ html: String, expectedHead: String, encoding: String.Encoding = .utf8, file: StaticString = #file, line: UInt = #line) {
         // when
         sut.addData(html.data(using: encoding)!)
-        
+
         // then
         XCTAssertTrue(sut.reachedEndOfHead, "Should reach end of head", file: file, line: line)
         guard let head = sut.head else { return XCTFail("Head was nil", file: file, line: line) }
         XCTAssertEqual(head, expectedHead, "Should have expected head", file: file, line: line)
     }
-    
+
     func assertThatItUpdatesReachedEndOfHeadWhenItReceivedHead(_ head: String, shouldUpdate: Bool = true, encoding: String.Encoding = .utf8, line: UInt = #line) {
         // given
         let first = "First".data(using: encoding)!
         let second = "Head".data(using: encoding)!
         let fourth = "End".data(using: encoding)!
-        
+
         // when & then
         sut.addData(first)
         XCTAssertFalse(sut.reachedEndOfHead, line: line)
-        
+
         // when & then
         sut.addData(second)
         XCTAssertFalse(sut.reachedEndOfHead, line: line)
-        
+
         // when & then
         sut.addData(head.data(using: encoding)!)
         XCTAssertEqual(sut.reachedEndOfHead, shouldUpdate, line: line)
-        
+
         // when & then
         sut.addData(fourth)
         XCTAssertEqual(sut.reachedEndOfHead, shouldUpdate, line: line)

--- a/WireLinkPreviewTests/NSDataDetectorLinksTests.swift
+++ b/WireLinkPreviewTests/NSDataDetectorLinksTests.swift
@@ -121,5 +121,4 @@ class NSDataDetectorLinksTests: XCTestCase {
         XCTAssertEqual(links.count, 1)
     }
 
-
 }

--- a/WireLinkPreviewTests/OpenGraphDataTests.swift
+++ b/WireLinkPreviewTests/OpenGraphDataTests.swift
@@ -30,7 +30,7 @@ class OpenGraphDataTests: XCTestCase {
         let images = ["www.example.com/image"]
 
         // when
-        guard let sut = OpenGraphData(propertyMapping: mapping, resolvedURL: URL(string: url)!, images: images) else { return XCTFail() }
+        guard let sut = OpenGraphData(propertyMapping: mapping, resolvedURL: URL(string: url)!, images: images) else { return XCTFail("SUT is nil") }
 
         // then
         XCTAssertEqual(sut.title, title)

--- a/WireLinkPreviewTests/OpenGraphDataTests.swift
+++ b/WireLinkPreviewTests/OpenGraphDataTests.swift
@@ -16,12 +16,11 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import XCTest
 @testable import WireLinkPreview
 
 class OpenGraphDataTests: XCTestCase {
-    
+
     func testThatItCreatesAValidOpenGraphDataFromPropertyMapping() {
         // given
         let title = "title"
@@ -29,10 +28,10 @@ class OpenGraphDataTests: XCTestCase {
         let type = "article"
         let mapping: [OpenGraphPropertyType: String] = [.title: title, .type: type, .description: name, .url: url]
         let images = ["www.example.com/image"]
-        
+
         // when
         guard let sut = OpenGraphData(propertyMapping: mapping, resolvedURL: URL(string: url)!, images: images) else { return XCTFail() }
-        
+
         // then
         XCTAssertEqual(sut.title, title)
         XCTAssertEqual(sut.type, type)
@@ -58,71 +57,71 @@ class OpenGraphDataTests: XCTestCase {
         XCTAssertNotNil(sut)
         XCTAssertEqual(sut?.type, "website")
     }
-    
+
     func testThatItReturnsNilWhenRequiredPropertiesAreMissing() {
         // given
         let title = "title"
         let mapping: [OpenGraphPropertyType: String] = [.title: title, .description: name]
         let images = ["www.example.com/image"]
-        
+
         // when
         let sut = OpenGraphData(propertyMapping: mapping, resolvedURL: URL(string: "www.example.com/image")!, images: images)
-        
+
         // then
         XCTAssertNil(sut)
     }
-    
+
     func testThatItSetsTheCorrectSiteName() {
         [OpenGraphSiteName.twitter, .youtube, .vimeo, .instagram, .foursquare].forEach { siteName in
             asserThatItSetsTheCorrectSiteName(siteName.rawValue, expected: siteName)
             asserThatItSetsTheCorrectSiteName(siteName.rawValue.capitalized, expected: siteName)
         }
     }
-    
+
     func testThatItCreatesTheCorrectLinkPreview_Twitter() {
         assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.twitterData(), expectedClass: TwitterStatusMetadata.self)
     }
-    
+
     func testThatItCreatesTheCorrectLinkPreview_TwitterWithImages() {
         assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.twitterDataWithImages(), expectedClass: TwitterStatusMetadata.self)
     }
-    
+
     func testThatItCreatesTheCorrectLinkPreview_TheVerge() {
         assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.vergeData(), expectedClass: ArticleMetadata.self)
     }
-    
+
     func testThatItCreatesTheCorrectLinkPreview_Foursqaure() {
         assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.foursquareData(), expectedClass: ArticleMetadata.self)
     }
-    
+
     func testThatItCreatesTheCorrectLinkPreview_Nytimes() {
         assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.nytimesData(), expectedClass: ArticleMetadata.self)
     }
-    
+
     func testThatItCreatesTheCorrectLinkPreview_Guardian() {
         assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.guardianData(), expectedClass: ArticleMetadata.self)
     }
-    
+
     func testThatItCreatesTheCorrectLinkPreview_Youtube() {
         assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.youtubeData())
     }
-    
+
     func testThatItCreatesTheCorrectLinkPreview_Vimeo() {
         assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.vimeoData())
     }
-    
+
     func testThatItCreatesTheCorrectLinkPreview_Instagram() {
         assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.instagramData(), expectedClass: ArticleMetadata.self)
     }
-    
+
     func testThatItCreatesTheCorrectLinkPreview_WashingtonPost() {
         assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.washingtonPostData(), expectedClass: ArticleMetadata.self)
     }
-    
+
     func testThatItCreatesTheCorrectLinkPreview_Medium() {
         assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.mediumData(), expectedClass: ArticleMetadata.self)
     }
-    
+
     func testThatItCreatesTheCorrectLinkPreview_Polygon() {
         assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.polygonData(), expectedClass: ArticleMetadata.self)
     }
@@ -134,7 +133,7 @@ class OpenGraphDataTests: XCTestCase {
     func testThatItCreatesTheCorrectLinkPreview_iTunesWithoutTitle() {
         assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.iTunesDataWithoutTitle(), expectedClass: ArticleMetadata.self)
     }
-    
+
     func testThatItCreatesTheCorrectLinkPreview_YahooSports() {
         assertLinkPreviewMapping(ofOpenGraphData: OpenGraphMockDataProvider.yahooSports(), expectedClass: ArticleMetadata.self)
     }
@@ -143,16 +142,16 @@ class OpenGraphDataTests: XCTestCase {
         // given
         let data = OpenGraphMockDataProvider.foursquareData().expected
         let originalURLString = "www.example.com"
-        
+
         // when
         let preview = data?.linkPreview(originalURLString, offset: 42)
-        
+
         // then
         XCTAssertEqual(preview?.characterOffsetInText, 42)
         XCTAssertEqual(preview?.originalURLString, originalURLString)
         XCTAssertNotEqual(preview?.permanentURL?.absoluteString, originalURLString)
     }
-    
+
     // MARK: - Helper
 
     func asserThatItSetsTheCorrectSiteName(_ siteNameString: String, expected: OpenGraphSiteName, line: UInt = #line) {
@@ -162,14 +161,14 @@ class OpenGraphDataTests: XCTestCase {
         let type = "article"
         let mapping: [OpenGraphPropertyType: String] = [.title: title, .type: type, .siteName: siteNameString, .url: url]
         let images = ["www.example.com/image"]
-        
+
         // when
         guard let sut = OpenGraphData(propertyMapping: mapping, resolvedURL: URL(string: url)!, images: images) else { return XCTFail(line: line) }
-        
+
         XCTAssertEqual(sut.siteName, expected, line: line)
         XCTAssertEqual(sut.siteNameString, siteNameString, line: line)
     }
-    
+
     func assertLinkPreviewMapping(ofOpenGraphData openGraphData: OpenGraphMockData, expectedClass: AnyClass = LinkMetadata.self, expectedFailure: Bool = false, line: UInt = #line) {
         if let linkPreview = openGraphData.expected?.linkPreview(openGraphData.urlString, offset: 12) {
             XCTAssertFalse(expectedFailure, line: line)
@@ -178,5 +177,5 @@ class OpenGraphDataTests: XCTestCase {
             XCTAssertTrue(expectedFailure, "No link preview present", line: line)
         }
     }
-    
+
 }

--- a/WireLinkPreviewTests/OpenGraphMockDataProvider.swift
+++ b/WireLinkPreviewTests/OpenGraphMockDataProvider.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import Foundation
 @testable import WireLinkPreview
 
@@ -30,7 +29,7 @@ struct OpenGraphMockData {
 class OpenGraphMockDataProvider: NSObject {
 
     static func twitterData() -> OpenGraphMockData {
-        
+
         let expected = OpenGraphData(
             title: "ericasadun on Twitter",
             type: "article",
@@ -48,9 +47,9 @@ class OpenGraphMockDataProvider: NSObject {
             urlVersion: nil
         )
     }
-    
+
     static func twitterDataWithImages() -> OpenGraphMockData {
-        
+
         let expected = OpenGraphData(
             title: "Ayaka Nonaka on Twitter",
             type: "article",
@@ -61,7 +60,7 @@ class OpenGraphMockDataProvider: NSObject {
             description: "“Hello from Lake Tahoe. Happy weekend everyone! ✌🏼️💙❤️”",
             userGeneratedImage: true
         )
-        
+
         return OpenGraphMockData(
             head: fixtureWithName("twitter_images_head"),
             expected: expected,
@@ -69,9 +68,9 @@ class OpenGraphMockDataProvider: NSObject {
             urlVersion: nil
         )
     }
-    
+
     static func foursquareData() -> OpenGraphMockData {
-        
+
         var expected = OpenGraphData(
             title: "NETA Mexican Street Food",
             type: "playfoursquare:venue",
@@ -81,7 +80,7 @@ class OpenGraphMockDataProvider: NSObject {
             siteName: "Foursquare",
             description: "Burrito-Imbiss in Berlin, Berlin"
         )
-        
+
         expected.foursquareMetaData = FoursquareMetaData(latitude: 52.53084856462712, longitude: 13.4021941476607)
 
         return OpenGraphMockData(
@@ -148,7 +147,7 @@ class OpenGraphMockDataProvider: NSObject {
             urlVersion: "20170918063647"
         )
     }
-    
+
     static func crashingDataEmoji() -> OpenGraphMockData {
         let expected = OpenGraphData(
             title: "Wall posts ",
@@ -159,7 +158,7 @@ class OpenGraphMockDataProvider: NSObject {
             siteName: nil,
             description: "📍 xxxxx"
         )
-        
+
         return OpenGraphMockData(
             head: fixtureWithName("crash_emoji"),
             expected: expected,
@@ -167,7 +166,7 @@ class OpenGraphMockDataProvider: NSObject {
             urlVersion: nil
         )
     }
-    
+
     static func instagramData() -> OpenGraphMockData {
         let expected = OpenGraphData(
             title: "Instagram photo by Silvan Dähn • Aug 5, 2015 at 4:27pm UTC",
@@ -223,7 +222,7 @@ class OpenGraphMockDataProvider: NSObject {
             urlVersion: "20180523034751"
         )
     }
-    
+
     static func washingtonPostData() -> OpenGraphMockData {
         let expected = OpenGraphData(
             title: "Holocaust Museum to visitors: Please stop catching Pokémon here",
@@ -234,7 +233,7 @@ class OpenGraphMockDataProvider: NSObject {
             siteName: "Washington Post",
             description: "Melding the real world with a digital one can sometimes lead to uncomfortable consequences."
         )
-        
+
         return OpenGraphMockData(
             head: fixtureWithName("washington_post_head"),
             expected: expected,
@@ -242,7 +241,7 @@ class OpenGraphMockDataProvider: NSObject {
             urlVersion: "20180519102639"
         )
     }
-    
+
     static func mediumData() -> OpenGraphMockData {
         let expected = OpenGraphData(
             title: "The tune for this summer — audio filters — Wire News",
@@ -253,7 +252,7 @@ class OpenGraphMockDataProvider: NSObject {
             siteName: "Medium",
             description: "Hello again from the Wire news room. Even though it’s a hot summer out there, we have been busy making our app the most modern, private…"
         )
-        
+
         return OpenGraphMockData(
             head: fixtureWithName("medium_head"),
             expected: expected,
@@ -261,7 +260,7 @@ class OpenGraphMockDataProvider: NSObject {
             urlVersion: nil
         )
     }
-    
+
     static func wireData() -> OpenGraphMockData {
         let expected = OpenGraphData(
             title: "Wire — modern, private communication. For iOS, Android, OS X, Windows and web.",
@@ -271,7 +270,7 @@ class OpenGraphMockDataProvider: NSObject {
             imageUrls: ["https://lh3.ggpht.com/gbxDT30ZwpwYMCF7ilrSaIpRQP3Z1Xdx2WUcyW5x_e8FDN8kA4CJGQQ0fFpVhKiGnPkAIOEf7S1_9cNi684Be-OY=s1024"],
             description: "HD quality calls, private and group chats with inline photos, music and video. Secure and perfectly synced across your devices."
         )
-        
+
         return OpenGraphMockData(
             head: fixtureWithName("wire_head"),
             expected: expected,
@@ -290,7 +289,7 @@ class OpenGraphMockDataProvider: NSObject {
             siteName: "Polygon",
             description: "How to answer one of the game's toughest questions"
         )
-        
+
         return OpenGraphMockData(
             head: fixtureWithName("polygon_head"),
             expected: expected,
@@ -336,7 +335,7 @@ class OpenGraphMockDataProvider: NSObject {
             urlVersion: nil
         )
     }
-    
+
     static func yahooSports() -> OpenGraphMockData {
         let expected = OpenGraphData(
             title: "Mario Gomez: Besiktas verlängert Leihe",
@@ -347,7 +346,7 @@ class OpenGraphMockDataProvider: NSObject {
             siteName: "Yahoo Sport",
             description: "Der deutsche Stürmer spielt offenbar auch in der kommenden Saison in Istanbul. Die Türken leihen ihn demnach erneut aus. Ein wichtiges Argument sei die Champions League."
         )
-        
+
         return OpenGraphMockData(
             head: fixtureWithName("yahoo_sports_head"),
             expected: expected,
@@ -394,15 +393,12 @@ class OpenGraphMockDataProvider: NSObject {
         )
     }
 
-
-
-
     // MARK: - Helper
-    
+
     private static func fixtureWithName(_ name: String) -> String {
         let bundle = Bundle(for: OpenGraphMockDataProvider.self)
         let url = bundle.url(forResource: name, withExtension: "txt")!
         return try! String(contentsOf: url)
     }
-    
+
 }

--- a/WireLinkPreviewTests/OpenGraphScannerTests.swift
+++ b/WireLinkPreviewTests/OpenGraphScannerTests.swift
@@ -16,16 +16,15 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import XCTest
 @testable import WireLinkPreview
 
 class OpenGraphScannerTests: XCTestCase {
-    
+
     func testThatItCanParseCorrectlyStrippedSampleData_Twitter() {
         assertThatItParsesSampleDataCorrectly(OpenGraphMockDataProvider.twitterData())
     }
-    
+
     func testThatItCanParseCorrectlyStrippedSampleData_TwitterWithImages() {
         assertThatItParsesSampleDataCorrectly(OpenGraphMockDataProvider.twitterDataWithImages())
     }
@@ -33,7 +32,7 @@ class OpenGraphScannerTests: XCTestCase {
     func testThatItCanParseCorrectlyStrippedSampleData_Verge() {
         assertThatItParsesSampleDataCorrectly(OpenGraphMockDataProvider.vergeData())
     }
-    
+
     func testThatItCanParseCorrectlyStrippedSampleData_Foursquare() {
         assertThatItParsesSampleDataCorrectly(OpenGraphMockDataProvider.foursquareData())
     }
@@ -57,11 +56,11 @@ class OpenGraphScannerTests: XCTestCase {
     func testThatItCanParseCorrectlyStrippedSampleData_NYTimes() {
         assertThatItParsesSampleDataCorrectly(OpenGraphMockDataProvider.nytimesData())
     }
-    
+
     func testThatItCanParseCorrectlyStrippedSampleData_WashingtonPost() {
         assertThatItParsesSampleDataCorrectly(OpenGraphMockDataProvider.washingtonPostData())
     }
-    
+
     func testThatItCanParseCorrectlyStrippedSampleData_Wire() {
         assertThatItParsesSampleDataCorrectly(OpenGraphMockDataProvider.wireData())
     }
@@ -77,7 +76,7 @@ class OpenGraphScannerTests: XCTestCase {
     func testThatItCanParseCorrectlyStrippedSampleData_iTunesWithoutTitle() {
         assertThatItParsesSampleDataCorrectly(OpenGraphMockDataProvider.iTunesDataWithoutTitle())
     }
-    
+
     func testThatItCanParseCorrectlyStrippedSampleData_yahooSports() {
         assertThatItParsesSampleDataCorrectly(OpenGraphMockDataProvider.yahooSports())
     }
@@ -85,7 +84,7 @@ class OpenGraphScannerTests: XCTestCase {
     func testThatItCanParseCorrectlyStrippedSampleData_VK_Emoji_crash() {
         assertThatItParsesSampleDataCorrectly(OpenGraphMockDataProvider.crashingDataEmoji())
     }
-    
+
     func assertThatItParsesSampleDataCorrectly(_ mockData: OpenGraphMockData, line: UInt = #line) {
         // given
         var receivedData: OpenGraphData?
@@ -100,7 +99,7 @@ class OpenGraphScannerTests: XCTestCase {
         XCTAssertEqual(mockData.expected?.title, receivedData?.title, line: line)
         XCTAssertEqual(mockData.expected?.type, receivedData?.type, line: line)
         XCTAssertEqual(mockData.expected?.url, receivedData?.url, line: line)
-        
+
         XCTAssertEqual(mockData.expected?.imageUrls ?? [], receivedData?.imageUrls ?? [], line: line)
         XCTAssertEqual(mockData.expected?.siteName, receivedData?.siteName, line: line)
         XCTAssertEqual(mockData.expected?.siteNameString, receivedData?.siteNameString, line: line)
@@ -110,5 +109,5 @@ class OpenGraphScannerTests: XCTestCase {
 
         XCTAssertEqual(mockData.expected, receivedData, line: line)
     }
-    
+
 }

--- a/WireLinkPreviewTests/PreviewBlackListTests.swift
+++ b/WireLinkPreviewTests/PreviewBlackListTests.swift
@@ -16,7 +16,6 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import XCTest
 @testable import WireLinkPreview
 

--- a/WireLinkPreviewTests/PreviewDownloaderTests.swift
+++ b/WireLinkPreviewTests/PreviewDownloaderTests.swift
@@ -77,7 +77,7 @@ class PreviewDownloaderTests: XCTestCase {
         sut.processReceivedData(firstBytes, forTask: mockDataTask, withIdentifier: taskID)
 
         // then
-        guard let container = sut.containerByTaskID[taskID] else { return XCTFail() }
+        guard let container = sut.containerByTaskID[taskID] else { return XCTFail("container is nil") }
         XCTAssertEqual(container.bytes, firstBytes)
 
         // when

--- a/WireLinkPreviewTests/PreviewDownloaderTests.swift
+++ b/WireLinkPreviewTests/PreviewDownloaderTests.swift
@@ -16,11 +16,8 @@
 // along with this program. If not, see http://www.gnu.org/licenses/.
 // 
 
-
 import XCTest
 @testable import WireLinkPreview
-
-
 
 class PreviewDownloaderTests: XCTestCase {
 
@@ -119,7 +116,7 @@ class PreviewDownloaderTests: XCTestCase {
         XCTAssertEqual(mockDataTask.cancelCallCount, 1)
         XCTAssertEqual(completionCallCount, 1)
     }
-    
+
     func testThatItCallsTheCompletionHandler_IfThereIsNoClosingHeadTag_AndTheDataTaskIsCompleted() {
         // given
         let completionExpectation = expectation(description: "It should call the completion handler")
@@ -131,20 +128,20 @@ class PreviewDownloaderTests: XCTestCase {
         let taskID = 0
         let firstBytes = " First Part\n ".data(using: String.Encoding.utf8)!
         let secondBytes = " Second Part\n ".data(using: String.Encoding.utf8)!
-        
+
         // when
         sut.requestOpenGraphData(fromURL: url, completion: completion)
         sut.processReceivedData(firstBytes, forTask: mockDataTask, withIdentifier: taskID)
-        
+
         // then
         XCTAssertEqual(mockDataTask.cancelCallCount, 0)
         XCTAssertEqual(mockDataTask.state, .running)
         XCTAssertEqual(completionCallCount, 0)
-        
+
         // when
         mockDataTask.state = .completed
         sut.processReceivedData(secondBytes, forTask: mockDataTask, withIdentifier: taskID)
-        
+
         // then
         waitForExpectations(timeout: 0.2, handler: nil)
         XCTAssertEqual(mockDataTask.cancelCallCount, 0)
@@ -168,51 +165,51 @@ class PreviewDownloaderTests: XCTestCase {
         XCTAssertNil(sut.completionByURL[url])
         XCTAssertNil(sut.containerByTaskID[taskID])
     }
-    
+
     func testThatItCallsTheCompletionAndCleansUpIfItReceivesANetworkError() {
         // given
         let completionExpectation = expectation(description: "It should call the completion handler")
         let completion: PreviewDownloader.DownloadCompletion = { _ in completionExpectation.fulfill() }
         let firstBytes = " <head> ".data(using: String.Encoding.utf8)!
         let taskID = 0
-        
+
         // when
         sut.requestOpenGraphData(fromURL: url, completion: completion)
         let error = NSError(domain: name, code: 0, userInfo: nil)
         sut.processReceivedData(firstBytes, forTask: mockDataTask, withIdentifier: taskID)
         sut.urlSession(mockSession, task: mockDataTask, didCompleteWithError: error)
-        
+
         // then
         waitForExpectations(timeout: 0.2, handler: nil)
         XCTAssertEqual(mockDataTask.cancelCallCount, 0)
         XCTAssertNil(sut.completionByURL[url])
         XCTAssertNil(sut.containerByTaskID[taskID])
     }
-    
+
     func testThatItDoesNotCallTheCompletionAndCleansUpIfItReceivesANilError() {
         // given
         let firstBytes = " <head> </head>".data(using: String.Encoding.utf8)!
         let completion: PreviewDownloader.DownloadCompletion = { _ in }
         let taskID = 0
-        
+
         // when
         sut.requestOpenGraphData(fromURL: url, completion: completion)
         sut.processReceivedData(firstBytes, forTask: mockDataTask, withIdentifier: taskID)
         sut.urlSession(mockSession, task: mockDataTask, didCompleteWithError: nil)
-        
+
         // then
         XCTAssertEqual(mockDataTask.cancelCallCount, 1)
         XCTAssertNotNil(sut.completionByURL[url])
         XCTAssertNotNil(sut.containerByTaskID[taskID])
     }
-    
+
     func testThatItDoesntCallTheCompletionWhenRequestIsCancelled() {
         // given
         let error = NSError(domain: NSURLErrorDomain, code: URLError.cancelled.rawValue, userInfo: nil)
-        
+
         // expect
         let completion: PreviewDownloader.DownloadCompletion = { _ in XCTFail("It should not call the completion handler") }
-        
+
         // when
         sut.requestOpenGraphData(fromURL: url, completion: completion)
         sut.cancel(task: mockDataTask)
@@ -235,14 +232,14 @@ class PreviewDownloaderTests: XCTestCase {
         XCTAssertNil(sut.completionByURL[url])
         XCTAssertNil(sut.containerByTaskID[taskID])
     }
-    
+
     func testThatItOverridesTheContentTypeOfTheURLSessionUsedForParsing() {
         // given
         let completion: PreviewDownloader.DownloadCompletion = { _ in }
-        
+
         // when
         sut.requestOpenGraphData(fromURL: url, completion: completion)
-        
+
         // then
         let expected = "Wire LinkPreview Bot"
         XCTAssertEqual(mockSession.dataTaskWithURLCallCount, 1)
@@ -253,7 +250,7 @@ class PreviewDownloaderTests: XCTestCase {
         XCTAssertEqual(mockDataTask.resumeCallCount, 1)
         XCTAssertNotNil(sut.completionByURL[url])
     }
-    
+
     func testThatItCallsTheCompletionHandlerAndCancelsTheRequestIfTheContentTypeOfTheResponseIfNotHTML() {
         assertThatItCallsTheDipositionHandler(.cancel, contentType: "something-other-than-html")
     }
@@ -261,19 +258,19 @@ class PreviewDownloaderTests: XCTestCase {
     func testThatItCallsTheCompletionHandlerAndCancelsTheRequestIfTheStatusIsNotSuccessful() {
         assertThatItCallsTheDipositionHandler(.cancel, contentType: "text/html", statusCode: 404)
     }
-    
+
     func testThatItCallsTheDispositionHandlerWithAllowAndDoesNotCallTheDownloadCompletionForContentTypeHTML() {
         assertThatItCallsTheDipositionHandler(.allow, contentType: "text/html")
     }
-    
+
     func testThatItCallsTheDispositionHandlerWithAllowAndDoesNotCallTheDownloadCompletionForContentTypeHTMLWithCharset() {
         assertThatItCallsTheDipositionHandler(.allow, contentType: "text/html;charset=utf-8")
     }
-    
+
     func testThatItCallsTheDispositionHandlerWithAllowAndDoesNotCallTheDownloadCompletionForContentTypeHTMLUppercase() {
         assertThatItCallsTheDipositionHandler(.allow, contentType: "TEXT/HTML")
     }
-    
+
     func assertThatItCallsTheDipositionHandler(_ expected: URLSession.ResponseDisposition, contentType: String, statusCode: Int = 200, line: UInt = #line) {
         // given
         let downloadExpectation = expectation(description: "It should call the downloader completion handler")
@@ -282,7 +279,7 @@ class PreviewDownloaderTests: XCTestCase {
         let originalRequest = URLRequest(url: URL(string: "www.example.com")!)
         sut.requestOpenGraphData(fromURL: url, completion: completion)
         sut.processReceivedData("bytes".data(using: .utf8)!, forTask: mockDataTask, withIdentifier: 0)
-        
+
         // when
         let response = HTTPURLResponse(
             url: originalRequest.url!,
@@ -290,13 +287,13 @@ class PreviewDownloaderTests: XCTestCase {
             httpVersion: nil,
             headerFields: ["Content-Type": contentType]
         )
-        
-        var disposition: URLSession.ResponseDisposition? = nil
+
+        var disposition: URLSession.ResponseDisposition?
         sut.urlSession(sut.session, dataTask: mockDataTask, didReceiveHTTPResponse: response!) {
             disposition = $0
             sessionExpectation.fulfill()
         }
-        
+
         if expected == .allow {
             downloadExpectation.fulfill()
         }
@@ -311,9 +308,7 @@ class PreviewDownloaderTests: XCTestCase {
             XCTAssertNotNil(sut.completionByURL[url], line: line)
             XCTAssertNotNil(sut.containerByTaskID[mockDataTask.taskIdentifier], line: line)
         }
-        
+
     }
-    
+
 }
-
-

--- a/WireLinkPreviewTests/StringXMLEntityParserTests.swift
+++ b/WireLinkPreviewTests/StringXMLEntityParserTests.swift
@@ -20,89 +20,89 @@ import XCTest
 @testable import WireLinkPreview
 
 final class StringXMLEntityParserTests: XCTestCase {
-    
+
     func testThatItIgnoresEmptyString() {
         // given 
         let string = ""
         // when & then
         XCTAssertEqual(string, string.removingHTMLEntities())
     }
-    
+
     func testThatItIgnoresStringWithoutEntities() {
         // given
         let string = "WebKit crashes on background thread"
         // when & then
         XCTAssertEqual(string, string.removingHTMLEntities())
     }
-    
+
     func testThatItIgnoresStringWithOneAmp() {
         // given
         let string = "NSAttributedString crashes on background thread & no one tells that it uses WebKit"
         // when & then
         XCTAssertEqual(string, string.removingHTMLEntities())
     }
-    
+
     func testThatItIgnoresStringWithSeveralAmps() {
         // given
         let string = "if webKit && thread.current().isBackground() then fatalError()"
         // when & then
         XCTAssertEqual(string, string.removingHTMLEntities())
     }
-    
+
     func testThatItIgnoresStringWithEmoji() {
         // given
         let string = "WebKit crashes on background thread 😱"
         // when & then
         XCTAssertEqual(string, string.removingHTMLEntities())
     }
-    
+
     func testThatItIgnoresStringWithRTL() {
         // given
         let string = "تحطم بكت على موضوع الخلفية"
         // when & then
         XCTAssertEqual(string, string.removingHTMLEntities())
     }
-    
+
     func testThatItIgnoresStringWithChineese() {
         // given
         let string = "在后台线程WebKit的崩溃"
         // when & then
         XCTAssertEqual(string, string.removingHTMLEntities())
     }
-    
+
     func testThatItReplacesAmp() {
         // given
         let string = "&amp;"
         // when & then
         XCTAssertEqual("&", string.removingHTMLEntities())
     }
-    
+
     func testThatItReplacesSeveralAmps() {
         // given
         let string = "if webKit &amp;&amp; thread.current().isBackground() then fatalError()"
         // when & then
         XCTAssertEqual("if webKit && thread.current().isBackground() then fatalError()", string.removingHTMLEntities())
     }
-    
+
     func testThatItReplacesQuot() {
         // given
         let string = "I said: &quot;WebKit crashes on background thread&quot;"
         // when & then
         XCTAssertEqual("I said: \"WebKit crashes on background thread\"", string.removingHTMLEntities())
     }
-    
+
     func testThatItReplacesSpecialCharacters() {
         // given
         let string = "Checkout: 0,00 &#8364;"
         // when & then
         XCTAssertEqual("Checkout: 0,00 €", string.removingHTMLEntities())
     }
-    
+
     func testThatItReplacesSeveralSpecialCharacters() {
         // given
         let string = "Restaurant is &#8364;&#8364;&#8364;"
         // when & then
         XCTAssertEqual("Restaurant is €€€", string.removingHTMLEntities())
     }
-    
+
 }

--- a/WireLinkPreviewTests/URLMocks.swift
+++ b/WireLinkPreviewTests/URLMocks.swift
@@ -19,22 +19,22 @@
 @testable import WireLinkPreview
 
 class MockURLSessionDataTask: URLSessionDataTaskType {
-    
+
     var taskIdentifier = 0
     var resumeCallCount = 0
     var cancelCallCount = 0
-    var mockOriginalRequest: URLRequest? = nil
+    var mockOriginalRequest: URLRequest?
     var state: URLSessionTask.State = .completed
-    
+
     var originalRequest: URLRequest? {
         return mockOriginalRequest
     }
-    
+
     func resume() {
         resumeCallCount += 1
         state = .running
     }
-    
+
     func cancel() {
         cancelCallCount += 1
         state = .canceling
@@ -42,20 +42,20 @@ class MockURLSessionDataTask: URLSessionDataTaskType {
 }
 
 class MockURLSession: URLSessionType {
-    
+
     var dataTaskWithURLCallCount = 0
     var dataTaskWithURLParameters = [URLRequest]()
     var dataTaskWithURLClosureCallCount = 0
     var dataTaskWithURLClosureCompletions = [DataTaskCompletion]()
-    var mockDataTask: MockURLSessionDataTask? = nil
-    var dataTaskGenerator: ((URL, DataTaskCompletion) -> URLSessionDataTaskType)? = nil
-    
+    var mockDataTask: MockURLSessionDataTask?
+    var dataTaskGenerator: ((URL, DataTaskCompletion) -> URLSessionDataTaskType)?
+
     func dataTask(with request: URLRequest) -> URLSessionDataTaskType {
         dataTaskWithURLCallCount += 1
         dataTaskWithURLParameters.append(request)
         return mockDataTask!
     }
-    
+
     func dataTaskWithURL(_ url: URL, completionHandler: @escaping DataTaskCompletion) -> URLSessionDataTaskType {
         dataTaskWithURLClosureCallCount += 1
         dataTaskWithURLClosureCompletions.append(completionHandler)


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [ ] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With this PR I fixed warnings for the following SwiftLint rules: 

- **Opening Brace Spacing Violation**: Opening braces should be preceded by a single space and on the same line as the declaration. `(opening_brace)`
- **Colon Violation**: Colons should be next to the identifier when specifying a type and next to the key in dictionary literals. `(colon)`
- **Trailing Whitespace Violation**: Lines should not have trailing whitespace. `(trailing_whitespace)`
- **Redundant Nil Coalescing**: nil coalescing operator is only evaluated if the lhs is nil, coalescing operator with nil as rhs is redundant `(redundant_nil_coalescing)`
- **Comma Spacing Violation**: There should be no space before and one after any comma. `(comma_referencing)`
- **Vertical Parameter Alignment Violation**: Function parameters should be aligned vertically if they're in multiple lines in a declaration. `(vertical_parameter_alignment)`
- **Redundant String Enum Value Violation**: String enum values can be omitted when they are equal to the enumcase name. `(redundant_string_enum_value)`
- **Operator Function Whitespace Violation**: Operators should be surrounded by a single whitespace when defining them. `(operator_whitespace)`
- **Identifier Name Violation**: Variable name should be between 3 and 40 characters long: 'og' `(identifier_name)`
- **XCTFail Message Violation**: An XCTFail call should include a description of the assertion. `(xctfail_message)`
- **Redundant @objc Attribute Violation**: Objective-C attribute (@objc) is redundant in declaration. `(redundant_objc_attribute)`

In addition to that I removed a bunch of rules from the list since by having them enabled, they don't produce any warnings or errors.

 - `generic_type_name`
 -  `force_cast`
 - `type_name`
 - `large_tuple`
 - `unused_setter_value`
 - `notification_center_detachment`
 - `discarded_notification_center_observer`
 - `cyclomatic_complexity`
 - `closure_parameter_position`
 - `statement_position`
 - `weak_delegate`
 - `class_delegate_protocol`
 - `legacy_cggeometry_functions`
 - `legacy_constructor`
 - `legacy_hashing`
 - `multiple_closures_with_trailing_closure`
 - `nesting`
 - `function_parameter_count`
 - `compiler_protocol_init`
 - `reduce_boolean`
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
